### PR TITLE
Prepare for MeilisSearch v0.11.0 : Use new error handler to check if index already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ private struct Movie: Codable, Equatable {
 ## Compatibility with MeiliSearch
 
 This package is compatible with the following MeiliSearch versions:
-- `v0.10.X`
+- `v0.11.X`
 
 ## Functions
 

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -81,34 +81,6 @@ struct Indexes {
 
     }
 
-    enum CreateError: Swift.Error {
-        case indexAlreadyExists
-
-        static func decode(_ error: MSError) -> Swift.Error {
-
-            let underlyingError: NSError = error.underlying as NSError
-
-            if let data = error.data {
-
-                let msErrorResponse: MSErrorResponse?
-                do {
-                    let decoder: JSONDecoder = JSONDecoder()
-                    msErrorResponse = try decoder.decode(MSErrorResponse.self, from: data)
-                } catch {
-                    msErrorResponse = nil
-                }
-
-                if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
-                    return CreateError.indexAlreadyExists
-                }
-                return error
-
-            }
-
-            return error
-        }
-    }
-
     func create(
         _ UID: String,
         _ completion: @escaping (Result<Index, Swift.Error>) -> Void) {
@@ -218,4 +190,32 @@ struct CreateIndexPayload: Codable {
 
 struct UpdateIndexPayload: Codable {
     let name: String
+}
+
+public enum CreateError: Swift.Error, Equatable {
+    case indexAlreadyExists
+
+    static func decode(_ error: MSError) -> Swift.Error {
+
+        let underlyingError: NSError = error.underlying as NSError
+
+        if let data = error.data {
+
+            let msErrorResponse: MSErrorResponse?
+            do {
+                let decoder: JSONDecoder = JSONDecoder()
+                msErrorResponse = try decoder.decode(MSErrorResponse.self, from: data)
+            } catch {
+                msErrorResponse = nil
+            }
+
+            if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
+                return CreateError.indexAlreadyExists
+            }
+            return error
+
+        }
+
+        return error
+    }
 }

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -98,7 +98,7 @@ struct Indexes {
                     msErrorResponse = nil
                 }
 
-                if underlyingError.code == 400 && msErrorResponse?.message == "Impossible to create index; index already exists" {
+                if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
                     return CreateError.indexAlreadyExists
                 }
                 return error

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -26,11 +26,11 @@ struct MSError: Swift.Error {
     let underlying: Swift.Error
 }
 
-struct MSErrorResponse: Decodable {
+struct MSErrorResponse: Codable {
   let message: String
   let errorCode: String
   let errorType: String
-  let errorLink: String
+  let errorLink: String?
 }
 
 final class Request {

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -28,6 +28,9 @@ struct MSError: Swift.Error {
 
 struct MSErrorResponse: Decodable {
   let message: String
+  let errorCode: String
+  let errorType: String
+  let errorLink: String
 }
 
 final class Request {

--- a/Tests/MeiliSearchTests/IndexesTests.swift
+++ b/Tests/MeiliSearchTests/IndexesTests.swift
@@ -98,7 +98,7 @@ class IndexesTests: XCTestCase {
         //Prepare the mock server
 
         let createJsonString = """
-        {"message":"Impossible to create index; index already exists"}
+        {"message":"Impossible to create index; index already exists","errorType":"invalid_request_error","errorCode":"index_already_exists"}
         """
 
         session.pushError(createJsonString, nil, code: 400)


### PR DESCRIPTION
It must be merged once the MeiliSearch `v0.11.0` is released. This version includes `errorCode`, `errorType` and `errorLink` in answer body.

Warning:
The answer body still includes a `message` attribute, but the error message for "This index already exists" error will change. So this PR has to be merged as quickly as possible once the v11 is out because this package will not work with the v11 without this fix.
So it's normal that the tests fail right now.