### PR TITLE
Error handler

### DIFF
--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Download and Run  MeiliSearch
-      run: curl -L https://install.meilisearch.com | sh && ./meilisearch --no-analytics=true --master-key='masterKey'
+      run: sudo curl -L https://install.meilisearch.com | sh ; sleep 2 
+    - name: Run MeiliSearch
+      run: chmod +x meilisearch ; ls -la ;  ./meilisearch &
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        swift-version: '5.2.0'
     - name: Docker setup
       run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
     - name: Run tests

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Docker setup
-      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
+    - name: Download MeiliSearch
+      run: curl -L https://install.meilisearch.com | sh
+    - name: Run MeiliSearch
+      run: ./meilisearch --no-analytics=true --master-key='masterKey'
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         swift-version: '5.2.0'
-
+    - name: Docker setup
+        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -14,9 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Download MeiliSearch
-      run: curl -L https://install.meilisearch.com | sh
-    - name: Run MeiliSearch
-      run: ./meilisearch --no-analytics=true --master-key='masterKey'
+    - name: Download and Run  MeiliSearch
+      run: curl -L https://install.meilisearch.com | sh && ./meilisearch --no-analytics=true --master-key='masterKey'
     - name: Run tests
       run: swift test -v

--- a/.github/workflows/swift-test.yml
+++ b/.github/workflows/swift-test.yml
@@ -17,6 +17,6 @@ jobs:
       with:
         swift-version: '5.2.0'
     - name: Docker setup
-        run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
+      run: docker run -d -p 7700:7700 getmeili/meilisearch:latest ./meilisearch --no-analytics=true --master-key='masterKey'
     - name: Run tests
       run: swift test -v

--- a/Sources/MeiliSearch/Config.swift
+++ b/Sources/MeiliSearch/Config.swift
@@ -63,7 +63,10 @@ public class Config {
     // MARK: Build
 
     func url(api: String) -> String {
-        hostURL! + api
+        guard let hostURL = self.hostURL else {
+            return api
+        }
+        return hostURL + api
     }
 
     // MARK: Validate

--- a/Sources/MeiliSearch/Config.swift
+++ b/Sources/MeiliSearch/Config.swift
@@ -13,7 +13,7 @@ public class Config {
 
     /// Default config instance set up to use localhost and port 7700.
     public static func `default`(
-        with apiKey: String = "",
+        with apiKey: String = "masterKey",
         session: URLSessionProtocol = URLSession.shared) -> Config {
         Config(hostURL: "http://localhost:7700", apiKey: apiKey, session: session)
     }

--- a/Sources/MeiliSearch/Config.swift
+++ b/Sources/MeiliSearch/Config.swift
@@ -21,7 +21,7 @@ public class Config {
     // MARK: Properties
 
     /// Address for the MeiliSearch server.
-    let hostURL: String
+    let hostURL: String?
 
     /// API key needed for the production environment.
     let apiKey: String
@@ -37,7 +37,7 @@ public class Config {
      - parameter hostURL: Address for the MeiliSearch server.
      - parameter apiKey:  API key needed for the production environment.
      */
-    public init(hostURL: String = "", apiKey: String = "") {
+    public init(hostURL: String? = nil, apiKey: String = "") {
         self.hostURL = hostURL
         self.apiKey = apiKey
         self.session = URLSession.shared
@@ -52,7 +52,7 @@ public class Config {
      - parameter session:  A custom produced URLSessionProtocol.
     */
     public init(
-        hostURL: String,
+        hostURL: String?,
         apiKey: String = "",
         session: URLSessionProtocol) {
         self.hostURL = hostURL
@@ -63,7 +63,7 @@ public class Config {
     // MARK: Build
 
     func url(api: String) -> String {
-        hostURL + api
+        hostURL! + api
     }
 
     // MARK: Validate
@@ -73,11 +73,11 @@ public class Config {
      */
     func validate(_ request: Request) throws -> Config {
 
-        if self.hostURL.isEmpty {
+        guard let hostURL = self.hostURL else {
             return self
         }
 
-        guard let _ = URL(string: self.hostURL) else {
+        guard let _ = URL(string: hostURL) else {
             throw MeiliSearch.Error.hostNotValid
         }
 

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -196,26 +196,17 @@ public enum CreateError: Swift.Error, Equatable {
     case indexAlreadyExists
 
     static func decode(_ error: MSError) -> Swift.Error {
-
+        // print("CREATE ERROR")
+        // print(error)
         let underlyingError: NSError = error.underlying as NSError
-
-        if let data = error.data {
-
-            let msErrorResponse: MSErrorResponse?
-            do {
-                let decoder: JSONDecoder = JSONDecoder()
-                msErrorResponse = try decoder.decode(MSErrorResponse.self, from: data)
-            } catch {
-                msErrorResponse = nil
-            }
-
-            if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
+        // print(underlyingError)
+        if let msErrorResponse: MSErrorResponse = error.data {
+            if underlyingError.code == 400 && msErrorResponse.errorType == "invalid_request_error" && msErrorResponse.errorCode == "index_already_exists" {
                 return CreateError.indexAlreadyExists
             }
             return error
 
         }
-
         return error
     }
 }

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -196,10 +196,7 @@ public enum CreateError: Swift.Error, Equatable {
     case indexAlreadyExists
 
     static func decode(_ error: MSError) -> Swift.Error {
-        // print("CREATE ERROR")
-        // print(error)
         let underlyingError: NSError = error.underlying as NSError
-        // print(underlyingError)
         if let msErrorResponse: MSErrorResponse = error.data {
             if underlyingError.code == 400 && msErrorResponse.errorType == "invalid_request_error" && msErrorResponse.errorCode == "index_already_exists" {
                 return CreateError.indexAlreadyExists

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -21,8 +21,10 @@ public protocol URLSessionDataTaskProtocol {
     func resume()
 }
 
+// struct meiliSearchApiError: Codable
+
 struct MSError: Swift.Error {
-    let data: Data?
+    let data: MSErrorResponse?
     let underlying: Swift.Error
 }
 
@@ -73,10 +75,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)        
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -99,9 +110,9 @@ final class Request {
         request.httpBody = data
 
         let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
-
+            
             if let error: Swift.Error = error {
-                let msError = MSError(data: data, underlying: error)
+                let msError = MSError(data: nil, underlying: error)
                 completion(.failure(msError))
                 return
             }
@@ -111,10 +122,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -150,10 +170,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)        
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -183,10 +212,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)        
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -62,11 +62,24 @@ final class Request {
           request.addValue(value, forHTTPHeaderField: key)
         }
 
-        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, _, error) in
+        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
             if let error: Swift.Error = error {
                 completion(.failure(error))
                 return
             }
+
+            guard let response = response as? HTTPURLResponse else {
+                fatalError("Correct handles invalid response, please create a custom error type")
+            }
+
+            if 400 ... 599 ~= response.statusCode {
+                completion(.failure(
+                  MSError(
+                    data: data,
+                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                return
+            }
+
             completion(.success(data))
         }
 
@@ -126,11 +139,24 @@ final class Request {
         request.httpMethod = "PUT"
         request.httpBody = body
 
-        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, _, error) in
+        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
             if let error: Swift.Error = error {
                 completion(.failure(error))
                 return
             }
+
+            guard let response = response as? HTTPURLResponse else {
+                fatalError("Correct handles invalid response, please create a custom error type")
+            }
+
+            if 400 ... 599 ~= response.statusCode {
+                completion(.failure(
+                  MSError(
+                    data: data,
+                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                return
+            }
+
             completion(.success(data))
         }
 
@@ -146,11 +172,24 @@ final class Request {
         var request: URLRequest = URLRequest(url: URL(string: urlString)!)
         request.httpMethod = "DELETE"
 
-        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, _, error) in
+        let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
             if let error: Swift.Error = error {
                 completion(.failure(error))
                 return
             }
+
+            guard let response = response as? HTTPURLResponse else {
+                fatalError("Correct handles invalid response, please create a custom error type")
+            }
+
+            if 400 ... 599 ~= response.statusCode {
+                completion(.failure(
+                  MSError(
+                    data: data,
+                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                return
+            }
+
             completion(.success(data))
         }
 

--- a/Tests/MeiliSearchTests/ClientTests.swift
+++ b/Tests/MeiliSearchTests/ClientTests.swift
@@ -4,7 +4,6 @@ import XCTest
 class ClientTests: XCTestCase {
 
   func testValidHostURL() {
-    let client: MeiliSearch = try! MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey"))
     XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey")))
   }
 

--- a/Tests/MeiliSearchTests/ClientTests.swift
+++ b/Tests/MeiliSearchTests/ClientTests.swift
@@ -3,23 +3,19 @@ import XCTest
 
 class ClientTests: XCTestCase {
 
-  private let session = MockURLSession()
-
   func testValidHostURL() {
-    session.pushEmpty(code: 200)
-    XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "", session: session)))
+    let client: MeiliSearch = try! MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey"))
+    XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey")))
   }
 
   func testEmptyHostURL() {
-    session.pushError(nil, NSError(domain: "any", code: 404, userInfo: nil), code: 404)
-    XCTAssertThrowsError(try MeiliSearch(Config(hostURL: "http://localhost:7700", session: session))) { error in
+    XCTAssertThrowsError(try MeiliSearch(Config(hostURL: "http://localhost:1234"))) { error in
       XCTAssertEqual(error as! MeiliSearch.Error, MeiliSearch.Error.serverNotFound)
     }
   }
 
   func testNotValidHostURL() {
-    session.pushError(nil, NSError(domain: "any", code: 404, userInfo: nil), code: 404)
-    XCTAssertThrowsError(try MeiliSearch(Config(hostURL: "Not valid host", session: session))) { error in
+    XCTAssertThrowsError(try MeiliSearch(Config(hostURL: "Not valid host"))) { error in
       XCTAssertEqual(error as! MeiliSearch.Error, MeiliSearch.Error.hostNotValid)
     }
   }

--- a/Tests/MeiliSearchTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchTests/DocumentsTests.swift
@@ -29,7 +29,10 @@ class DocumentsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "http://localhost:7700"))
+
+        if client == nil {
+            client = try! MeiliSearch(Config.default)
+        }
 
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
 

--- a/Tests/MeiliSearchTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchTests/DocumentsTests.swift
@@ -6,17 +6,71 @@ private struct Movie: Codable, Equatable {
 
     let id: Int
     let title: String
-    let overview: String
-    let releaseDate: Date
+    let comment: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case title
-        case overview
-        case releaseDate = "release_date"
+        case comment
+    }
+    init(id: Int, title: String, comment: String? = nil) {
+        self.id = id
+        self.title = title
+        self.comment = comment
     }
 
 }
+
+private let movies = [
+    Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
+    Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
+    Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
+    Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
+    Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
+    Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
+    Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
+    
+]
+let documentJsonString = """
+[
+    {
+        "id": 123,
+        "title": "Pride and Prejudice",
+        "comment": "A great book"
+    },
+    {
+        "id": 456,
+        "title": "Le Petit Prince",
+        "comment": "A french book"
+    },
+    {
+        "id": 2,
+        "title": "Le Rouge et le Noir",
+        "comment": "Another french book"
+    },
+    {
+        "id": 1,
+        "title": "Alice In Wonderland",
+        "comment": "A weird book"
+    },
+    {
+        "id": 1344,
+        "title": "The Hobbit",
+        "comment": "An awesome book"
+    },
+    {
+        "id": 4,
+        "title": "Harry Potter and the Half-Blood Prince",
+        "comment": "The best book"
+    },
+    {
+        "id": 42,
+        "title": "The Hitchhiker's Guide to the Galaxy"
+    }
+]
+"""
+
+let uid: String = "books_test"
 
 class DocumentsTests: XCTestCase {
 
@@ -29,322 +83,208 @@ class DocumentsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
+        
         if client == nil {
             client = try! MeiliSearch(Config.default)
         }
-
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.getOrCreateIndex(UID: "books_test") { result in
+        self.client.deleteIndex(UID: uid) { result in
             switch result {
-            case .success(let index):
-                print("INDEX")
-                print(index)
-                expectation.fulfill()
-            case .failure(let error):
-                print(error)
-                print("ERROR")
-//                XCTFail("Failed to create Index")
+            case .success:
+                print("Index deleted")
+                self.client.getOrCreateIndex(UID: uid) { result in
+                    switch result {
+                    case .success:
+                        print("Index Created")
+                        expectation.fulfill()
+                    case .failure(let error):
+                        print(error)
+                        expectation.fulfill()
+                    }
+                }
+            case .failure:
                 expectation.fulfill()
             }
         }
-        self.wait(for: [expectation], timeout: 2.0)
         
+        self.wait(for: [expectation], timeout: 2.0)
     }
 
-    func testAddDocuments() {
+    func testAddAndGetDocuments() {
+        let documents: Data = try! JSONEncoder().encode(movies)
 
-        //Prepare the mock server
+        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.addDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Failed to add or replace Movies document")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.getDocuments(
+            UID: uid,
+            limit: 20
+        ) { (result: Result<[Movie], Swift.Error>) in
 
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        // Start the test with the mocked server
-
-        let uid: String = "books_test"
-
-        let documentJsonString = """
-        [{
-            "id": 287947,
-            "title": "Shazam",
-            "poster": "https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg",
-            "overview": "A boy is given the ability to become an adult superhero in times of need with a single magic word.",
-            "release_date": "2019-03-23"
-        }]
-        """
-
-        let primaryKey: String = ""
-
-        let documents: Data = documentJsonString.data(using: .utf8)!
-
+            switch result {
+            case .success(let returnedMovies):
+                print("HELLO")
+                print(returnedMovies)
+                XCTAssertEqual(movies, returnedMovies)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+    
+    func testAddAndGetOneDocuments() {
+        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+        let documents: Data = try! JSONEncoder().encode([movie])
+//        print(jsonData)
+//        let documents: Data = documentJsonString.data(using: .utf8)!
+//        let jsonString = String(data: jsonData, encoding: .utf8)!
+//        print(jsonString)
+//        let documents: Data = jsonString.data(using: .utf8)!
+//        print(jsonString)
+        
         let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
         self.client.addDocuments(
             UID: uid,
             documents: documents,
-            primaryKey: primaryKey) { result in
-
+            primaryKey: nil
+        ) { result in
             switch result {
             case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+
+            switch result {
+            case .success(let returnedMovie):
+                print("HELLO")
+                print(returnedMovie)
+                XCTAssertEqual(movie, returnedMovie)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+    
+    func testUpdateAndGetDocuments() {
+        // FAILS
+        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+        let documents: Data = try! JSONEncoder().encode([movie])
+        
+        let expectation = XCTestExpectation(description: "Add or update Movies document")
+
+        self.client.updateDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+
+            switch result {
+            case .success(let returnedMovie):
+                print("HELLO")
+                print(returnedMovie)
+                XCTAssertEqual(movie, returnedMovie)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+
+    func testDeleteOneDocument(){
+        let documents: Data = try! JSONEncoder().encode(movies)
+
+        let expectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.addDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
                 expectation.fulfill()
             case .failure:
                 XCTFail("Failed to add or replace Movies document")
             }
-
         }
-
         self.wait(for: [expectation], timeout: 1.0)
-
+        sleep(1)
+        let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.deleteDocument(UID: uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 1), update)
+                deleteExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [deleteExpectation], timeout: 3.0)
+        
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+            switch result {
+            case .success:
+                XCTFail("Movie should not exist")
+            case .failure(let error):
+                // How can I get information from the error
+//                print(underlyingError.HttpStatus)
+                getExpectation.fulfill()
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+        
+        
     }
-
-//    func testUpdateDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//
-//        let documentJsonString = """
-//        [{
-//            "id": 287947,
-//            "title": "Shazam ⚡️"
-//        }]
-//        """
-//
-//        let primaryKey: String = "movieskud"
-//
-//        let documents: Data = documentJsonString.data(using: .utf8)!
-//
-//        let expectation = XCTestExpectation(description: "Add or update Movies document")
-//
-//        self.client.updateDocuments(
-//            UID: uid,
-//            documents: documents,
-//            primaryKey: primaryKey) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to add or update Movies document")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testGetDocument() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {
-//            "id": 25684,
-//            "title": "American Ninja 5",
-//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-//            "release_date": "2020-04-04T19:59:49.259572Z"
-//        }
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-//        let data = jsonString.data(using: .utf8)!
-//        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//        let identifier: String = "25684"
-//
-//        let expectation = XCTestExpectation(description: "Get Movies document")
-//
-//      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
-//
-//            switch result {
-//            case .success(let movie):
-//                XCTAssertEqual(stubMovie, movie)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to get Movies document")
-//            }
-//
-//      }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testGetDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        [{
-//            "id": 25684,
-//            "release_date": "2020-04-04T19:59:49.259572Z",
-//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-//            "title": "American Ninja 5",
-//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
-//        },{
-//            "id": 468219,
-//            "title": "Dead in a Week (Or Your Money Back)",
-//            "release_date": "2020-04-04T19:59:49.259572Z",
-//            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-//            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
-//        }]
-//        """
-//
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-//        let data = jsonString.data(using: .utf8)!
-//        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//        let limit: Int = 10
-//
-//        let expectation = XCTestExpectation(description: "Get Movies documents")
-//
-//        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
-//
-//            switch result {
-//            case .success(let movies):
-//                XCTAssertEqual(stubMovies, movies)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to get Movies documents")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteDocument() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let identifier: String = "25684"
-//
-//        let expectation = XCTestExpectation(description: "Delete Movies document")
-//
-//        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete Movies document")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteAllDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-//
-//        self.client.deleteAllDocuments(UID: uid) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete all Movies documents")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteBatchDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
-//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-//
-//      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete all Movies documents")
-//            }
-//
-//      }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
 
     private func convertToDictionary(_ string: String) -> [String: Any] {
         if let data: Data = string.data(using: .utf8) {
@@ -369,10 +309,10 @@ class DocumentsTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testAddDocuments", testAddDocuments),
-//        ("testUpdateDocuments", testUpdateDocuments),
-//        ("testGetDocument", testGetDocument),
-//        ("testGetDocuments", testGetDocuments),
+        ("testAddAndGetDocuments", testAddAndGetDocuments),
+        ("testAddAndGetOneDocuments", testAddAndGetOneDocuments),
+        ("testUpdateAndGetDocuments", testUpdateAndGetDocuments),
+        ("testDeleteOneDocument", testDeleteOneDocument)
 //        ("testDeleteDocument", testDeleteDocument),
 //        ("testDeleteAllDocuments", testDeleteAllDocuments),
 //        ("testDeleteBatchDocuments", testDeleteBatchDocuments)

--- a/Tests/MeiliSearchTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchTests/DocumentsTests.swift
@@ -92,7 +92,7 @@ class DocumentsTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
+//                XCTAssertEqual(stubUpdate, update)
                 expectation.fulfill()
             case .failure:
                 XCTFail("Failed to add or replace Movies document")

--- a/Tests/MeiliSearchTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchTests/DocumentsTests.swift
@@ -21,12 +21,33 @@ private struct Movie: Codable, Equatable {
 class DocumentsTests: XCTestCase {
 
     private var client: MeiliSearch!
-
-    private let session = MockURLSession()
+    
+    override class func setUp() { // 1.
+           super.setUp()
+        // TODO: add getOrCreateIndex in this method but it does not work
+    }
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: "http://localhost:7700"))
+
+        let expectation = XCTestExpectation(description: "Create index if it does not exist")
+
+        self.client.getOrCreateIndex(UID: "books_test") { result in
+            switch result {
+            case .success(let index):
+                print("INDEX")
+                print(index)
+                expectation.fulfill()
+            case .failure(let error):
+                print(error)
+                print("ERROR")
+//                XCTFail("Failed to create Index")
+                expectation.fulfill()
+            }
+        }
+        self.wait(for: [expectation], timeout: 2.0)
+        
     }
 
     func testAddDocuments() {
@@ -41,11 +62,9 @@ class DocumentsTests: XCTestCase {
         let jsonData = jsonString.data(using: .utf8)!
         let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString, code: 202)
-
         // Start the test with the mocked server
 
-        let uid: String = "Movies"
+        let uid: String = "books_test"
 
         let documentJsonString = """
         [{
@@ -82,257 +101,247 @@ class DocumentsTests: XCTestCase {
 
     }
 
-    func testUpdateDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-
-        let documentJsonString = """
-        [{
-            "id": 287947,
-            "title": "Shazam ⚡️"
-        }]
-        """
-
-        let primaryKey: String = "movieskud"
-
-        let documents: Data = documentJsonString.data(using: .utf8)!
-
-        let expectation = XCTestExpectation(description: "Add or update Movies document")
-
-        self.client.updateDocuments(
-            UID: uid,
-            documents: documents,
-            primaryKey: primaryKey) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or update Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testGetDocument() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {
-            "id": 25684,
-            "title": "American Ninja 5",
-            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-            "release_date": "2020-04-04T19:59:49.259572Z"
-        }
-        """
-
-        session.pushData(jsonString, code: 200)
-
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-        let identifier: String = "25684"
-
-        let expectation = XCTestExpectation(description: "Get Movies document")
-
-      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
-
-            switch result {
-            case .success(let movie):
-                XCTAssertEqual(stubMovie, movie)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies document")
-            }
-
-      }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testGetDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        [{
-            "id": 25684,
-            "release_date": "2020-04-04T19:59:49.259572Z",
-            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-            "title": "American Ninja 5",
-            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
-        },{
-            "id": 468219,
-            "title": "Dead in a Week (Or Your Money Back)",
-            "release_date": "2020-04-04T19:59:49.259572Z",
-            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
-        }]
-        """
-
-        session.pushData(jsonString, code: 200)
-
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-        let limit: Int = 10
-
-        let expectation = XCTestExpectation(description: "Get Movies documents")
-
-        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
-
-            switch result {
-            case .success(let movies):
-                XCTAssertEqual(stubMovies, movies)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteDocument() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let identifier: String = "25684"
-
-        let expectation = XCTestExpectation(description: "Delete Movies document")
-
-        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteAllDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-        self.client.deleteAllDocuments(UID: uid) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteBatchDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
-      }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
+//    func testUpdateDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//
+//        let documentJsonString = """
+//        [{
+//            "id": 287947,
+//            "title": "Shazam ⚡️"
+//        }]
+//        """
+//
+//        let primaryKey: String = "movieskud"
+//
+//        let documents: Data = documentJsonString.data(using: .utf8)!
+//
+//        let expectation = XCTestExpectation(description: "Add or update Movies document")
+//
+//        self.client.updateDocuments(
+//            UID: uid,
+//            documents: documents,
+//            primaryKey: primaryKey) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to add or update Movies document")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testGetDocument() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {
+//            "id": 25684,
+//            "title": "American Ninja 5",
+//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
+//            "release_date": "2020-04-04T19:59:49.259572Z"
+//        }
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+//        let data = jsonString.data(using: .utf8)!
+//        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//        let identifier: String = "25684"
+//
+//        let expectation = XCTestExpectation(description: "Get Movies document")
+//
+//      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
+//
+//            switch result {
+//            case .success(let movie):
+//                XCTAssertEqual(stubMovie, movie)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to get Movies document")
+//            }
+//
+//      }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testGetDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        [{
+//            "id": 25684,
+//            "release_date": "2020-04-04T19:59:49.259572Z",
+//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+//            "title": "American Ninja 5",
+//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
+//        },{
+//            "id": 468219,
+//            "title": "Dead in a Week (Or Your Money Back)",
+//            "release_date": "2020-04-04T19:59:49.259572Z",
+//            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
+//            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
+//        }]
+//        """
+//
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+//        let data = jsonString.data(using: .utf8)!
+//        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//        let limit: Int = 10
+//
+//        let expectation = XCTestExpectation(description: "Get Movies documents")
+//
+//        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
+//
+//            switch result {
+//            case .success(let movies):
+//                XCTAssertEqual(stubMovies, movies)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to get Movies documents")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteDocument() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let identifier: String = "25684"
+//
+//        let expectation = XCTestExpectation(description: "Delete Movies document")
+//
+//        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete Movies document")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteAllDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
+//
+//        self.client.deleteAllDocuments(UID: uid) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete all Movies documents")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteBatchDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
+//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
+//
+//      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete all Movies documents")
+//            }
+//
+//      }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
 
     private func convertToDictionary(_ string: String) -> [String: Any] {
         if let data: Data = string.data(using: .utf8) {
@@ -358,12 +367,12 @@ class DocumentsTests: XCTestCase {
 
     static var allTests = [
         ("testAddDocuments", testAddDocuments),
-        ("testUpdateDocuments", testUpdateDocuments),
-        ("testGetDocument", testGetDocument),
-        ("testGetDocuments", testGetDocuments),
-        ("testDeleteDocument", testDeleteDocument),
-        ("testDeleteAllDocuments", testDeleteAllDocuments),
-        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
+//        ("testUpdateDocuments", testUpdateDocuments),
+//        ("testGetDocument", testGetDocument),
+//        ("testGetDocuments", testGetDocuments),
+//        ("testDeleteDocument", testDeleteDocument),
+//        ("testDeleteAllDocuments", testDeleteAllDocuments),
+//        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
     ]
 
 }

--- a/Tests/MeiliSearchTests/IndexesTests.swift
+++ b/Tests/MeiliSearchTests/IndexesTests.swift
@@ -8,7 +8,7 @@ class IndexesTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testCreateIndex() {

--- a/Tests/MeiliSearchTests/KeysTests.swift
+++ b/Tests/MeiliSearchTests/KeysTests.swift
@@ -8,7 +8,7 @@ class KeysTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testKeys() {

--- a/Tests/MeiliSearchTests/KeysTests.swift
+++ b/Tests/MeiliSearchTests/KeysTests.swift
@@ -8,7 +8,11 @@ class KeysTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: nil, session: session))
+        let config = Config(
+          hostURL: "",
+          apiKey: "c4dff5a196824a0704c2023916c21eaf0a13485a9d637416820bc623375f2a",
+          session: session)
+        client = try! MeiliSearch(config)
     }
 
     func testKeys() {

--- a/Tests/MeiliSearchTests/SearchTests.swift
+++ b/Tests/MeiliSearchTests/SearchTests.swift
@@ -26,7 +26,7 @@ class SearchTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testSearchForBotmanMovie() {

--- a/Tests/MeiliSearchTests/SettingsTests.swift
+++ b/Tests/MeiliSearchTests/SettingsTests.swift
@@ -37,7 +37,7 @@ class SettingsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     // MARK: Settings

--- a/Tests/MeiliSearchTests/StatsTests.swift
+++ b/Tests/MeiliSearchTests/StatsTests.swift
@@ -9,7 +9,7 @@ class StatsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testStats() {

--- a/Tests/MeiliSearchTests/SystemTests.swift
+++ b/Tests/MeiliSearchTests/SystemTests.swift
@@ -9,7 +9,7 @@ class SystemTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testHealth() {

--- a/Tests/MeiliSearchTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchTests/UpdatesTests.swift
@@ -8,7 +8,7 @@ class UpdatesTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "", session: session))
+        client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
     func testGetUpdate() {


### PR DESCRIPTION
## Error handler draft

This is a draft to make the errors more clear.
In order to achieve this, I use the error body from MeiliSearch to feed the error object.

## Test this branch
Because `apiKey` does not work #39, we will use that bug to test our error handler.


1. Run a MeiliSearch with a apikey
```
docker run -it --rm -p 7700:7700 getmeili/meilisearch:v0.13.0rc0 ./meilisearch  --no-analytics=true --master-key=masterKey
```

2. Run the tests 
```bash
swift test
```
3. Observe the output from the DocumentsTests

```bash
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:126: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : failed - The operation couldn’t be completed. (MeiliSearch.MSError error 1.)
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:129: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "Add or replace Movies document".
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:142: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : failed - The operation couldn’t be completed. (MeiliSearch.MSError error 1.)
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:145: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : Asynchronous wait failed: Exceeded timeout of 3 seconds, with unfulfilled expectations: "Add or replace Movies document".
```

In the case of `addDocuments` from the `testAddAndGetDocuments`, the error comes back to `addOrReplaceDocuments`
but does not comes back to the testing method.

When printing the error in `addOrReplaceDocuments` this is the output: 
```bash
MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "You must have an authorization token", errorCode: "missing_authorization_header", errorType: "authentication_error", errorLink: Optional("https://docs.meilisearch.com/errors#missing_authorization_header"))), underlying: Error Domain=HttpStatus Code=401 "(null)")
```

## Expected results
I would like the MSError to appear in the failed message from the tests.

```bash
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:126: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : failed - MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "You must have an authorization token", errorCode: "missing_authorization_header", errorType: "authentication_error", errorLink: Optional("https://docs.meilisearch.com/errors#missing_authorization_header"))), underlying: Error Domain=HttpStatus Code=401 "(null)")
/meili/meilisearch-swift/Tests/MeiliSearchTests/DocumentsTests.swift:129: error: -[MeiliSearchTests.DocumentsTests testAddAndGetDocuments] : Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "Add or replace Movies document".

```

## Important

This draft is buggy when meilisearch does not return an error (i.e if the api link does not exist). In which case it crashes because I try to decode it as a meiliSearch Error here:
```swift
// Request.swift
let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
```