### PR TITLE
[#48] Remove acceptNewFields routes

### DIFF
--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -661,38 +661,6 @@ public struct MeiliSearch {
         self.settings.resetDisplayedAttributes(UID, completion)
     }
 
-    // MARK: Accept New Fields
-
-    /**
-     Get the accept new fields field of an `Index`.
-
-     - parameter UID:        The unique identifier for the `Index` to be found.
-     - parameter completion: The completion closure used to notify when the server
-     completes the query request, it returns a `Result` object that contains `Bool`
-     value. If the request was sucessful or `Error` if a failure occured.
-     */
-    public func getAcceptNewFields(
-        UID: String,
-        _ completion: @escaping (Result<Bool, Swift.Error>) -> Void) {
-        self.settings.getAcceptNewFields(UID, completion)
-    }
-
-    /**
-     Update the accept new fields field of an `Index`.
-
-     - parameter UID:             The unique identifier for the `Index` to be found.
-     - parameter acceptNewFields: The accept new fields option to be applied into `Index`.
-     - parameter completion:      The completion closure used to notify when the server
-     completes the query request, it returns a `Result` object that contains `Update`
-     value. If the request was sucessful or `Error` if a failure occured.
-     */
-    public func updateAcceptNewFields(
-        UID: String,
-        _ acceptNewFields: Bool,
-        _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
-        self.settings.updateAcceptNewFields(UID, acceptNewFields, completion)
-    }
-
     // MARK: Attributes for faceting
 
     /**

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -166,7 +166,7 @@ struct Indexes {
         _ data: Data,
         _ completion: (Result<Index, Swift.Error>) -> Void) {
         do {
-            let index = try Constants.customJSONDecoder.decode(Index.self, from: data)
+            let index: Index = try Constants.customJSONDecoder.decode(Index.self, from: data)
 
             completion(.success(index))
         } catch {
@@ -178,7 +178,7 @@ struct Indexes {
         _ data: Data,
         _ completion: (Result<[Index], Swift.Error>) -> Void) {
         do {
-            let indexes = try Constants.customJSONDecoder.decode([Index].self, from: data)
+            let indexes: [Index] = try Constants.customJSONDecoder.decode([Index].self, from: data)
 
             completion(.success(indexes))
         } catch {

--- a/Sources/MeiliSearch/Model/Setting.swift
+++ b/Sources/MeiliSearch/Model/Setting.swift
@@ -3,53 +3,42 @@ import Foundation
 /**
  Each instance of MeiliSearch has three keys: a master, a private, and a public.
  Each key has a given set of permissions on the API routes.
-*/
+ */
 public struct Setting: Codable, Equatable {
 
     // MARK: Properties
 
-    ///List of ranking rules for a given `Index`.
+    /// List of ranking rules for a given `Index`.
     public let rankingRules: [String]
 
-    ///List of searchable attributes for a given `Index`.
+    /// List of searchable attributes for a given `Index`.
     public let searchableAttributes: [String]
 
-    ///List of displayed attributes for a given `Index`.
+    /// List of displayed attributes for a given `Index`.
     public let displayedAttributes: [String]
 
-    ///List of stop-words for a given `Index`.
+    /// List of stop-words for a given `Index`.
     public let stopWords: [String]
 
-    ///List of synonyms and its values for a given `Index`.
+    /// List of synonyms and its values for a given `Index`.
     public let synonyms: [String: [String]]
 
-    ///Return if a given `Index` allows new fields.
-    public let acceptNewFields: Bool
-
-    public init(
-      rankingRules: [String],
-      searchableAttributes: [String],
-      displayedAttributes: [String],
-      stopWords: [String],
-      synonyms: [String: [String]],
-      acceptNewFields: Bool) {
-      self.rankingRules = rankingRules
-      self.searchableAttributes = searchableAttributes
-      self.displayedAttributes = displayedAttributes
-      self.stopWords = stopWords
-      self.synonyms = synonyms
-      self.acceptNewFields = acceptNewFields
+    public init(rankingRules: [String], searchableAttributes: [String], displayedAttributes: [String], stopWords: [String], synonyms: [String: [String]]) {
+        self.rankingRules = rankingRules
+        self.searchableAttributes = searchableAttributes
+        self.displayedAttributes = displayedAttributes
+        self.stopWords = stopWords
+        self.synonyms = synonyms
     }
 
-    ///Tries to decode the JSON object to Setting object.
+    /// Tries to decode the JSON object to Setting object.
     public init(from decoder: Decoder) throws {
         let values = try? decoder.container(keyedBy: CodingKeys.self)
+
         rankingRules = (try? values?.decodeIfPresent([String].self, forKey: .rankingRules)) ?? []
-        searchableAttributes = (try? values?.decodeIfPresent([String].self, forKey: .searchableAttributes)) ?? []
-        displayedAttributes = (try? values?.decodeIfPresent([String].self, forKey: .displayedAttributes)) ?? []
+        searchableAttributes = (try? values?.decodeIfPresent([String].self, forKey: .searchableAttributes)) ?? ["*"]
+        displayedAttributes = (try? values?.decodeIfPresent([String].self, forKey: .displayedAttributes)) ?? ["*"]
         stopWords = (try? values?.decodeIfPresent([String].self, forKey: .stopWords)) ?? []
         synonyms = (try? values?.decodeIfPresent([String: [String]].self, forKey: .synonyms)) ?? [:]
-        acceptNewFields = (try? values?.decodeIfPresent(Bool.self, forKey: .acceptNewFields)) ?? false
     }
-
 }

--- a/Sources/MeiliSearch/Model/Setting.swift
+++ b/Sources/MeiliSearch/Model/Setting.swift
@@ -23,14 +23,6 @@ public struct Setting: Codable, Equatable {
     /// List of synonyms and its values for a given `Index`.
     public let synonyms: [String: [String]]
 
-    public init(rankingRules: [String], searchableAttributes: [String], displayedAttributes: [String], stopWords: [String], synonyms: [String: [String]]) {
-        self.rankingRules = rankingRules
-        self.searchableAttributes = searchableAttributes
-        self.displayedAttributes = displayedAttributes
-        self.stopWords = stopWords
-        self.synonyms = synonyms
-    }
-
     /// Tries to decode the JSON object to Setting object.
     public init(from decoder: Decoder) throws {
         let values = try? decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/MeiliSearch/Settings.swift
+++ b/Sources/MeiliSearch/Settings.swift
@@ -681,66 +681,6 @@ struct Settings {
 
     }
 
-    // MARK: Accept New Fields
-
-    func getAcceptNewFields(
-        _ UID: String,
-        _ completion: @escaping (Result<Bool, Swift.Error>) -> Void) {
-
-        self.request.get(api: "/indexes/\(UID)/settings/accept-new-fields") { result in
-
-            switch result {
-            case .success(let data):
-
-                guard let data: Data = data else {
-                    completion(.failure(MeiliSearch.Error.dataNotFound))
-                    return
-                }
-
-                let acceptNewFields: String = String(decoding: data, as: UTF8.self)
-
-                completion(.success(acceptNewFields == "true"))
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
-
-        }
-
-    }
-
-    func updateAcceptNewFields(
-        _ UID: String,
-        _ acceptNewFields: Bool,
-        _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
-
-        let acceptNewFieldsString: String = acceptNewFields ? "true" : "false"
-        guard let data: Data = acceptNewFieldsString.data(using: .ascii) else {
-            completion(.failure(MeiliSearch.Error.invalidJSON))
-            return
-        }
-
-        self.request.post(api: "/indexes/\(UID)/settings/accept-new-fields", data) { result in
-
-            switch result {
-            case .success(let data):
-
-                do {
-                    let decoder: JSONDecoder = JSONDecoder()
-                    let update: Update = try decoder.decode(Update.self, from: data)
-                    completion(.success(update))
-                } catch {
-                    completion(.failure(error))
-                }
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
-
-        }
-
-    }
-
     // MARK: Attributes for faceting
 
     func getAttributesForFaceting(

--- a/Sources/MeiliSearch/Stats.swift
+++ b/Sources/MeiliSearch/Stats.swift
@@ -27,7 +27,7 @@ struct Stats {
                 }
 
                 do {
-                    let stat = try Constants.customJSONDecoder.decode(Stat.self, from: data)
+                    let stat: Stat = try Constants.customJSONDecoder.decode(Stat.self, from: data)
 
                     completion(.success(stat))
                 } catch {
@@ -55,7 +55,7 @@ struct Stats {
                 }
 
                 do {
-                    let allStats = try Constants.customJSONDecoder.decode(AllStats.self, from: data)
+                    let allStats: AllStats = try Constants.customJSONDecoder.decode(AllStats.self, from: data)
                     
                     completion(.success(allStats))
                 } catch {

--- a/Sources/MeiliSearch/System.swift
+++ b/Sources/MeiliSearch/System.swift
@@ -57,7 +57,7 @@ struct System {
                 }
 
                 do {
-                    let vesion = try Constants.customJSONDecoder.decode(Version.self, from: data)
+                    let vesion: Version = try Constants.customJSONDecoder.decode(Version.self, from: data)
                     
                     completion(.success(vesion))
                 } catch {

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -31,7 +31,7 @@ struct Updates {
                 }
 
                 do {
-                    let result = try Constants.customJSONDecoder.decode(Update.Result.self, from: data)
+                    let result: Update.Result = try Constants.customJSONDecoder.decode(Update.Result.self, from: data)
 
                     completion(.success(result))
                 } catch {
@@ -61,7 +61,7 @@ struct Updates {
                 }
 
                 do {
-                    let result = try Constants.customJSONDecoder.decode([Update.Result].self, from: data)
+                    let result: [Update.Result] = try Constants.customJSONDecoder.decode([Update.Result].self, from: data)
                     
                     completion(.success(result))
                 } catch {

--- a/Tests/MeiliSearchUnitTests/IndexesTests.swift
+++ b/Tests/MeiliSearchUnitTests/IndexesTests.swift
@@ -27,7 +27,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
         session.pushData(jsonString)
 
@@ -67,7 +67,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
         session.pushData(jsonString)
 
@@ -113,7 +113,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = getJsonString.data(using: .utf8)!
 
-        let stubIndex = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
         session.pushData(getJsonString)
 
@@ -153,7 +153,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
         session.pushData(jsonString)
 
@@ -195,7 +195,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndexes = try! Constants.customJSONDecoder.decode([Index].self, from: jsonData)
+        let stubIndexes: [Index] = try! Constants.customJSONDecoder.decode([Index].self, from: jsonData)
 
         session.pushData(jsonString)
 
@@ -234,7 +234,7 @@ class IndexesTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
         session.pushData(jsonString)
 

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -60,7 +60,7 @@ class SearchTests: XCTestCase {
 
         let data = jsonString.data(using: .utf8)!
 
-        let stubSearchResult = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
+        let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
 
         session.pushData(jsonString)
 
@@ -119,7 +119,7 @@ class SearchTests: XCTestCase {
 
         let data = jsonString.data(using: .utf8)!
 
-        let stubSearchResult = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
+        let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
 
         session.pushData(jsonString)
 

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -41,7 +41,7 @@ class SettingsTests: XCTestCase {
     // MARK: Settings
 
     func testShouldInstantiateFromEmptyData() {
-        let stubSetting = buildStubSetting(from: "{}")
+        let stubSetting: Setting = buildStubSetting(from: "{}")
 
         XCTAssertTrue(stubSetting.rankingRules.isEmpty)
         XCTAssertEqual(stubSetting.searchableAttributes, ["*"])
@@ -54,7 +54,7 @@ class SettingsTests: XCTestCase {
 
         //Prepare the mock server
 
-        let stubSetting = buildStubSetting(from: json)
+        let stubSetting: Setting = buildStubSetting(from: json)
 
         session.pushData(json)
 
@@ -942,6 +942,7 @@ class SettingsTests: XCTestCase {
     }
 
     static var allTests = [
+        ("testShouldInstantiateFromEmptyData", testShouldInstantiateFromEmptyData),
         ("testGetSetting", testGetSetting),
         ("testUpdateSetting", testUpdateSetting),
         ("testResetSetting", testResetSetting),

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -17,7 +17,6 @@ class SettingsTests: XCTestCase {
             "exactness",
             "desc(release_date)"
         ],
-        "distinctAttribute": null,
         "searchableAttributes": ["title", "description", "uid"],
         "displayedAttributes": [
             "title",
@@ -30,8 +29,7 @@ class SettingsTests: XCTestCase {
         "synonyms": {
             "wolverine": ["xmen", "logan"],
             "logan": ["wolverine", "xmen"]
-        },
-        "acceptNewFields": false
+        }
     }
     """
 
@@ -42,11 +40,21 @@ class SettingsTests: XCTestCase {
 
     // MARK: Settings
 
+    func testShouldInstantiateFromEmptyData() {
+        let stubSetting = buildStubSetting(from: "{}")
+
+        XCTAssertTrue(stubSetting.rankingRules.isEmpty)
+        XCTAssertEqual(stubSetting.searchableAttributes, ["*"])
+        XCTAssertEqual(stubSetting.displayedAttributes, ["*"])
+        XCTAssertTrue(stubSetting.stopWords.isEmpty)
+        XCTAssertTrue(stubSetting.synonyms.isEmpty)
+    }
+
     func testGetSetting() {
 
         //Prepare the mock server
 
-        let stubSetting: Setting = buildStubSetting()
+        let stubSetting = buildStubSetting(from: json)
 
         session.pushData(json)
 
@@ -87,7 +95,7 @@ class SettingsTests: XCTestCase {
         // Start the test with the mocked server
 
         let UID: String = "movies"
-        let setting: Setting = buildStubSetting()
+        let setting: Setting = buildStubSetting(from: json)
 
         let expectation = XCTestExpectation(description: "Update settings")
 
@@ -824,74 +832,6 @@ class SettingsTests: XCTestCase {
 
     }
 
-    // MARK: Accept New Fields
-
-    func testGetAcceptNewFields() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        true
-        """
-
-        session.pushData(jsonString)
-
-        // Start the test with the mocked server
-
-        let UID: String = "movies"
-
-        let expectation = XCTestExpectation(description: "Get displayed attribute")
-
-        self.client.getAcceptNewFields(UID: UID) { result in
-            switch result {
-            case .success(let acceptNewFields):
-                XCTAssertTrue(acceptNewFields)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testUpdateAcceptNewFields() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
-
-        session.pushData(jsonString)
-
-        // Start the test with the mocked server
-
-        let UID: String = "movies"
-        let acceptNewFields = true
-
-        let expectation = XCTestExpectation(description: "Update displayed attribute")
-
-        self.client.updateAcceptNewFields(UID: UID, acceptNewFields) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
     // MARK: Attributes for faceting
 
     func testGetAttributesForFaceting() {
@@ -995,7 +935,7 @@ class SettingsTests: XCTestCase {
 
     }
 
-    private func buildStubSetting() -> Setting {
+    private func buildStubSetting(from json: String) -> Setting {
         let data = json.data(using: .utf8)!
         let decoder: JSONDecoder = JSONDecoder()
         return try! decoder.decode(Setting.self, from: data)
@@ -1020,8 +960,6 @@ class SettingsTests: XCTestCase {
         ("testGetDisplayedAttributes", testGetDisplayedAttributes),
         ("testUpdateDisplayedAttributes", testUpdateDisplayedAttributes),
         ("testResetDisplayedAttributes", testResetDisplayedAttributes),
-        ("testGetAcceptNewFields", testGetAcceptNewFields),
-        ("testUpdateAcceptNewFields", testUpdateAcceptNewFields),
         ("testGetAttributesForFaceting", testGetAttributesForFaceting),
         ("testUpdateAttributesForFaceting", testUpdateAttributesForFaceting),
         ("testResetAttributesForFaceting", testResetAttributesForFaceting)

--- a/Tests/MeiliSearchUnitTests/StatsTests.swift
+++ b/Tests/MeiliSearchUnitTests/StatsTests.swift
@@ -32,7 +32,7 @@ class StatsTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubStats = try! Constants.customJSONDecoder.decode(Stat.self, from: jsonData)
+        let stubStats: Stat = try! Constants.customJSONDecoder.decode(Stat.self, from: jsonData)
 
         session.pushData(jsonString)
 
@@ -91,7 +91,7 @@ class StatsTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubAllStats = try! Constants.customJSONDecoder.decode(AllStats.self, from: jsonData)
+        let stubAllStats: AllStats = try! Constants.customJSONDecoder.decode(AllStats.self, from: jsonData)
 
         session.pushData(jsonString)
 

--- a/Tests/MeiliSearchUnitTests/SystemTests.swift
+++ b/Tests/MeiliSearchUnitTests/SystemTests.swift
@@ -72,7 +72,7 @@ class SystemTests: XCTestCase {
 
         let jsonData = jsonString.data(using: .utf8)!
 
-        let stubVersion = try! Constants.customJSONDecoder.decode(Version.self, from: jsonData)
+        let stubVersion: Version = try! Constants.customJSONDecoder.decode(Version.self, from: jsonData)
 
         session.pushData(jsonString)
 

--- a/Tests/MeiliSearchUnitTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchUnitTests/UpdatesTests.swift
@@ -31,7 +31,7 @@ class UpdatesTests: XCTestCase {
 
         let data = json.data(using: .utf8)!
 
-        let stubResult = try! Constants.customJSONDecoder.decode(Update.Result.self, from: data)
+        let stubResult: Update.Result = try! Constants.customJSONDecoder.decode(Update.Result.self, from: data)
 
         session.pushData(json)
 
@@ -78,7 +78,7 @@ class UpdatesTests: XCTestCase {
 
         let data = json.data(using: .utf8)!
 
-        let stubResults = try! Constants.customJSONDecoder.decode([Update.Result].self, from: data)
+        let stubResults: [Update.Result] = try! Constants.customJSONDecoder.decode([Update.Result].self, from: data)
 
         session.pushData(json)
 


### PR DESCRIPTION
# Summary

Fixes #48.

Remove `acceptNewFields` routes and add default values for `searchableAttributes` and `displayedAttributes` in `Settings`.

# Miscellaneous

Added UT for testing default values and removed `distinctAttributes` from JSON test payload.