### PR TITLE
Cocoapods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,10 @@ docs/
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 #
 # Add this line if you want to avoid checking in source code from the Xcode workspace
-# *.xcworkspace
+*.xcworkspace
 
 # Carthage
 #

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,0 +1,6 @@
+use_frameworks!
+target 'MeiliSearch_Tests' do
+  pod 'MeiliSearch', :path => '../'
+  
+  
+end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - MeiliSearch (0.1.0)
+
+DEPENDENCIES:
+  - MeiliSearch (from `../`)
+
+EXTERNAL SOURCES:
+  MeiliSearch:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  MeiliSearch: 0ea6bb074c0724efc15426e30c3cfe3ce320788b
+
+PODFILE CHECKSUM: 31c7ecb519e14c4a42eeb8a1289429fe7fcc0f0c
+
+COCOAPODS: 1.9.3

--- a/Example/Tests/Info.plist
+++ b/Example/Tests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+class Tests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -1,0 +1,26 @@
+#
+# Be sure to run `pod lib lint MeiliSearch.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'MeiliSearch'
+  s.version          = '0.4.0'
+  s.summary          = 'MeiliSearch-Swift is a client for MeiliSearch written in Swift.'
+  s.description      = <<-DESC
+MeiliSearch-Swift is a client for MeiliSearch written in Swift. MeiliSearch is a powerful, fast, open-source, easy to use and deploy search engine. Both searching and indexing are highly customizable. Features such as typo-tolerance, filters, and synonyms are provided out-of-the-box.
+                       DESC
+
+  s.homepage         = 'https://github.com/meilisearch/meilisearch-swift'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'ppamorim' => 'pp.amorim@hotmail.com' }
+  s.source           = { :git => 'https://github.com/meilisearch/meilisearch-swift.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '9.3'
+
+  s.source_files = 'Sources/MeiliSearch/*', 'Sources/MeiliSearch/Model/*'
+  s.swift_versions = '5.0'
+end


### PR DESCRIPTION
## Summary

SwiftPM is nice and cool, but not everyone uses, knows or is able to use it. Knowing that the most known dependency manager for iOS projects is Cocoapods, this PR is here to adds the support (and a bit of boilerplate) of Cocoapods.

There are some requirements for this to work:

 - Please do **NOT** open the `xcworkspace` and do not test the project there, it's full of errors. Use only the SwiftPM part of the project to develop and test it. Remember, it's just a wrapper with the minimum configuration needed to have this release at Cocoapods.
 - That's the first time I add support to Cocoapods to a SwiftPM project, I am not 100% what each file does and what is necessary. If possible we will keep cutting these files down if we see that they are not needed to publish the project on Cocoapods.
 - Name the tag respecting the structure `x.x.x` instead of `vx.x.x`. This is a requirement from Cocoapods linter and it fails if it doesn't respect it.
 - After the merge of this PR, we will need to test it again locally and create a new release.

You can find the full tutorial explaining how to create a Cocoapods library here: https://guides.cocoapods.org/making/making-a-cocoapod.html
