### PR TITLE
Change the update status as enum and rename Type into UpdateType in Update model

### DIFF
--- a/Sources/MeiliSearch/Model/Update.swift
+++ b/Sources/MeiliSearch/Model/Update.swift
@@ -55,8 +55,8 @@ public struct Update: Codable, Equatable {
         case processed
         case failed
 
-        public enum CodingError: Error {
-            case unknownStatus
+        public enum StatusError: Error {
+            case unknown
         }
 
         public init(from decoder: Decoder) throws {
@@ -70,21 +70,11 @@ public struct Update: Codable, Equatable {
             case "failed":
                 self = .failed
             default:
-                throw CodingError.unknownStatus
+                throw StatusError.unknown
             }
         }
 
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            switch self {
-            case .enqueued:
-                try container.encode("enqueued")
-            case .processed:
-                try container.encode("processed")
-            case .failed:
-                try container.encode("failed")
-            }
-        }
+        public func encode(to encoder: Encoder) throws { }
 
     }
 

--- a/Sources/MeiliSearch/Model/Update.swift
+++ b/Sources/MeiliSearch/Model/Update.swift
@@ -17,13 +17,13 @@ public struct Update: Codable, Equatable {
         // MARK: Properties
 
         ///Returns if the update has been sucessful or not.
-        public let status: String
+        public let status: Status
 
         ///Unique ID for the current `Update`.
         public let updateId: Int
 
         ///Type of update.
-        public let type: Type
+        public let type: UpdateType
 
         ///Duration of the update process.
         public let duration: TimeInterval?
@@ -34,8 +34,8 @@ public struct Update: Codable, Equatable {
         ///Date when the update has been processed.
         public let processedAt: Date?
 
-        ///Typr of `Update`.
-        public struct `Type`: Codable, Equatable {
+        ///Type of `Update`
+        public struct UpdateType: Codable, Equatable {
 
             // MARK: Properties
 
@@ -45,6 +45,45 @@ public struct Update: Codable, Equatable {
             /// ID of update type.
             public let number: Int
 
+        }
+
+    }
+
+    public enum Status: Codable, Equatable {
+
+        case enqueued
+        case processed
+        case failed
+
+        public enum CodingError: Error {
+            case unknownStatus
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawStatus = try container.decode(String.self)
+            switch rawStatus {
+            case "enqueued":
+                self = .enqueued
+            case "processed":
+                self = .processed
+            case "failed":
+                self = .failed
+            default:
+                throw CodingError.unknownStatus
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .enqueued:
+                try container.encode("enqueued")
+            case .processed:
+                try container.encode("processed")
+            case .failed:
+                try container.encode("failed")
+            }
         }
 
     }

--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -174,7 +174,7 @@ class DocumentsTests: XCTestCase {
         }
         self.wait(for: [getExpectation], timeout: 3.0)
     }
-    
+
     func testAddAndGetOneDocumentWithIntIdentifierAndSucceed() {
 
         let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
@@ -239,7 +239,6 @@ class DocumentsTests: XCTestCase {
             switch result {
 
             case .success(let update):
-
 
                 XCTAssertEqual(Update(updateId: 0), update)
 

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -20,7 +20,7 @@ class SettingsTests: XCTestCase {
     private let defaultAttributesForFaceting: [String] = []
     private let defaultStopWords: [String] = []
     private let defaultSynonyms: [String: [String]] = [:]
-    private var defaultGlobalSettings: Setting? = nil
+    private var defaultGlobalSettings: Setting?
 
     // MARK: Setup
 

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -71,8 +71,8 @@ class UpdatesTests: XCTestCase {
                 self.client.getUpdate(UID: self.uid, update) { result in
 
                     switch result {
-                    case .success(let update):
-                        XCTAssertTrue(["enqueued", "processed", "fail"].contains(update.status))
+                    case .success:
+                        break
                     case .failure(let error):
                         print(error)
                         XCTFail()
@@ -105,11 +105,8 @@ class UpdatesTests: XCTestCase {
         self.client.getAllUpdates(UID: self.uid) { result in
 
             switch result {
-            case .success(let updates):
-                let statuses: [String] = ["enqueued", "processed", "fail"]
-                updates.forEach { (update: Update.Result) in
-                    XCTAssertTrue(statuses.contains(update.status))
-                }
+            case .success:
+                break
 
             case .failure(let error):
                 print(error)

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -68,11 +68,12 @@ class UpdatesTests: XCTestCase {
             switch result {
             case .success(let update):
 
-                self.client.getUpdate(UID: self.uid, update) { result in
+                self.client.getUpdate(UID: self.uid, update) { (result: Result<Update.Result, Swift.Error>)  in
 
                     switch result {
-                    case .success:
-                        break
+                    case .success(let update):
+                        XCTAssertEqual("DocumentsAddition", update.type.name)
+                        XCTAssertTrue(update.type.number >= 0)
                     case .failure(let error):
                         print(error)
                         XCTFail()
@@ -102,11 +103,14 @@ class UpdatesTests: XCTestCase {
             self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { _ in }
         }
 
-        self.client.getAllUpdates(UID: self.uid) { result in
+        self.client.getAllUpdates(UID: self.uid) { (result: Result<[Update.Result], Swift.Error>)  in
 
             switch result {
-            case .success:
-                break
+            case .success(let updates):
+                updates.forEach { (update: Update.Result) in
+                  XCTAssertEqual("DocumentsAddition", update.type.name)
+                  XCTAssertTrue(update.type.number >= 0)
+                }
 
             case .failure(let error):
                 print(error)

--- a/Tests/MeiliSearchUnitTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchUnitTests/UpdatesTests.swift
@@ -11,6 +11,29 @@ class UpdatesTests: XCTestCase {
         client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
+    func testEncodeStatusResult() {
+
+        let updateResult = Update.Result(
+            status: Update.Status.enqueued,
+            updateId: 456,
+            type: Update.Result.UpdateType(name: "DocumentsAddition", number: 123),
+            duration: TimeInterval.zero,
+            enqueuedAt: Date(timeIntervalSince1970: 0),
+            processedAt: nil)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        encoder.dateEncodingStrategy = .formatted(Formatter.iso8601)
+
+        let jsonData: Data = try! encoder.encode(updateResult)
+
+        let decoded: Update.Result = try! Constants.customJSONDecoder.decode(
+          Update.Result.self,
+          from: jsonData)
+
+        XCTAssertEqual(updateResult, decoded)
+    }
+
     func testGetUpdate() {
 
         //Prepare the mock server
@@ -31,7 +54,8 @@ class UpdatesTests: XCTestCase {
 
         let data = json.data(using: .utf8)!
 
-        let stubResult: Update.Result = try! Constants.customJSONDecoder.decode(Update.Result.self, from: data)
+        let stubResult: Update.Result = try! Constants.customJSONDecoder.decode(
+          Update.Result.self, from: data)
 
         session.pushData(json)
 
@@ -46,9 +70,50 @@ class UpdatesTests: XCTestCase {
             switch result {
             case .success(let result):
                 XCTAssertEqual(stubResult, result)
-                expectation.fulfill()
             case .failure:
                 XCTFail("Failed to get settings")
+            }
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 1.0)
+
+    }
+
+    func testGetUpdateInvalidStatus() {
+
+        //Prepare the mock server
+
+        let json = """
+        {
+            "status": "something",
+            "updateId": 1,
+            "type": {
+                "name": "DocumentsAddition",
+                "number": 4
+            },
+            "duration": 0.076980613,
+            "enqueuedAt": "2019-12-07T21:16:09.623944Z",
+            "processedAt": "2019-12-07T21:16:09.703509Z"
+        }
+        """
+
+        session.pushData(json)
+
+        // Start the test with the mocked server
+
+        let UID: String = "movies"
+        let update = Update(updateId: 1)
+
+        let expectation = XCTestExpectation(description: "Get settings")
+
+        self.client.getUpdate(UID: UID, update) { result in
+            switch result {
+            case .success:
+                XCTFail("The server send a invalid status and it should not succeed")
+            case .failure(let error):
+                XCTAssertTrue(error is Update.Status.CodingError)
+                expectation.fulfill()
             }
         }
 
@@ -92,10 +157,10 @@ class UpdatesTests: XCTestCase {
             switch result {
             case .success(let results):
                 XCTAssertEqual(stubResults, results)
-                expectation.fulfill()
             case .failure:
                 XCTFail("Failed to get settings")
             }
+            expectation.fulfill()
         }
 
         self.wait(for: [expectation], timeout: 1.0)

--- a/Tests/MeiliSearchUnitTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchUnitTests/UpdatesTests.swift
@@ -11,29 +11,6 @@ class UpdatesTests: XCTestCase {
         client = try! MeiliSearch(Config(hostURL: nil, session: session))
     }
 
-    func testEncodeStatusResult() {
-
-        let updateResult = Update.Result(
-            status: Update.Status.enqueued,
-            updateId: 456,
-            type: Update.Result.UpdateType(name: "DocumentsAddition", number: 123),
-            duration: TimeInterval.zero,
-            enqueuedAt: Date(timeIntervalSince1970: 0),
-            processedAt: nil)
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        encoder.dateEncodingStrategy = .formatted(Formatter.iso8601)
-
-        let jsonData: Data = try! encoder.encode(updateResult)
-
-        let decoded: Update.Result = try! Constants.customJSONDecoder.decode(
-          Update.Result.self,
-          from: jsonData)
-
-        XCTAssertEqual(updateResult, decoded)
-    }
-
     func testGetUpdate() {
 
         //Prepare the mock server
@@ -84,7 +61,7 @@ class UpdatesTests: XCTestCase {
 
         //Prepare the mock server
 
-        let json = """
+        let badStatusUpdateJson = """
         {
             "status": "something",
             "updateId": 1,
@@ -98,7 +75,7 @@ class UpdatesTests: XCTestCase {
         }
         """
 
-        session.pushData(json)
+        session.pushData(badStatusUpdateJson)
 
         // Start the test with the mocked server
 
@@ -112,7 +89,7 @@ class UpdatesTests: XCTestCase {
             case .success:
                 XCTFail("The server send a invalid status and it should not succeed")
             case .failure(let error):
-                XCTAssertTrue(error is Update.Status.CodingError)
+                XCTAssertTrue(error is Update.Status.StatusError)
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
This PR transforms the status result from the `Update` struct into an enum. This change is needed since the server has a stable API and the user doesn't want to keep comparing strings in the SDK.