### PR TITLE
Addd waitForPending update method

### DIFF
--- a/Sources/MeiliSearch/Model/Update.swift
+++ b/Sources/MeiliSearch/Model/Update.swift
@@ -34,7 +34,7 @@ public struct Update: Codable, Equatable {
         ///Date when the update has been processed.
         public let processedAt: Date?
 
-        ///Type of `Update`
+        ///Type of `Update`.
         public struct UpdateType: Codable, Equatable {
 
             // MARK: Properties
@@ -43,7 +43,7 @@ public struct Update: Codable, Equatable {
             public let name: String
 
             /// ID of update type.
-            public let number: Int
+            public let number: Int?
 
         }
 

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -31,8 +31,9 @@ struct Updates {
                 }
 
                 do {
-                    let result: Update.Result = try Constants.customJSONDecoder.decode(Update.Result.self, from: data)
-
+                    let result: Update.Result = try Constants.customJSONDecoder.decode(
+                        Update.Result.self,
+                        from: data)
                     completion(.success(result))
                 } catch {
                     completion(.failure(error))

--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -79,26 +79,28 @@ class DocumentsTests: XCTestCase {
 
                 XCTAssertEqual(Update(updateId: 0), update)
 
-                Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDocuments(
-                    UID: self.uid,
-                    limit: 20
-                ) { (result: Result<[Movie], Swift.Error>) in
+                    self.client.getDocuments(
+                        UID: self.uid,
+                        limit: 20
+                    ) { (result: Result<[Movie], Swift.Error>) in
 
-                    switch result {
-                    case .success(let returnedMovies):
+                        switch result {
+                        case .success(let returnedMovies):
 
-                        movies.forEach { (movie: Movie) in
-                            XCTAssertTrue(returnedMovies.contains(movie))
+                            movies.forEach { (movie: Movie) in
+                                XCTAssertTrue(returnedMovies.contains(movie))
+                            }
+
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
                         }
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        expectation.fulfill()
                     }
 
-                    expectation.fulfill()
                 }
 
             case .failure(let error):
@@ -110,52 +112,54 @@ class DocumentsTests: XCTestCase {
 
     }
 
-  func testAddDataAndGetDocuments() {
-      let documents: Data = try! JSONEncoder().encode(movies)
+    func testAddDataAndGetDocuments() {
+        let documents: Data = try! JSONEncoder().encode(movies)
 
-      let expectation = XCTestExpectation(description: "Add or replace Movies document")
+        let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
-      self.client.addDocuments(
-          UID: self.uid,
-          documents: documents,
-          primaryKey: nil
-      ) { result in
+        self.client.addDocuments(
+            UID: self.uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
 
-          switch result {
-          case .success(let update):
+            switch result {
+            case .success(let update):
 
-              XCTAssertEqual(Update(updateId: 0), update)
+                XCTAssertEqual(Update(updateId: 0), update)
 
-              Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-              self.client.getDocuments(
-                  UID: self.uid,
-                  limit: 20
-              ) { (result: Result<[Movie], Swift.Error>) in
+                    self.client.getDocuments(
+                        UID: self.uid,
+                        limit: 20
+                    ) { (result: Result<[Movie], Swift.Error>) in
 
-                  switch result {
-                  case .success(let returnedMovies):
+                        switch result {
+                        case .success(let returnedMovies):
 
-                      movies.forEach { (movie: Movie) in
-                          XCTAssertTrue(returnedMovies.contains(movie))
-                      }
+                            movies.forEach { (movie: Movie) in
+                                XCTAssertTrue(returnedMovies.contains(movie))
+                            }
 
-                  case .failure(let error):
-                      print(error)
-                      XCTFail()
-                  }
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
 
-                  expectation.fulfill()
-              }
+                        expectation.fulfill()
+                    }
 
-          case .failure(let error):
-              print(error)
-              XCTFail()
-          }
-      }
-      self.wait(for: [expectation], timeout: 5.0)
+                }
 
-  }
+            case .failure(let error):
+                    print(error)
+                    XCTFail()
+            }
+        }
+        self.wait(for: [expectation], timeout: 5.0)
+
+    }
 
     func testGetOneDocumentAndFail() {
 
@@ -173,7 +177,7 @@ class DocumentsTests: XCTestCase {
         }
         self.wait(for: [getExpectation], timeout: 3.0)
     }
-
+    
     func testAddAndGetOneDocumentWithIntIdentifierAndSucceed() {
 
         let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
@@ -191,25 +195,28 @@ class DocumentsTests: XCTestCase {
 
             case .success(let update):
 
+
                 XCTAssertEqual(Update(updateId: 0), update)
 
-                Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-               self.client.getDocument(
-                   UID: self.uid,
-                   identifier: 10
-               ) { (result: Result<Movie, Swift.Error>) in
+                    self.client.getDocument(
+                    UID: self.uid,
+                    identifier: 10
+                    ) { (result: Result<Movie, Swift.Error>) in
 
-                   switch result {
-                   case .success(let returnedMovie):
-                       XCTAssertEqual(movie, returnedMovie)
-                   case .failure(let error):
-                       print(error)
-                       XCTFail()
-                   }
-                   expectation.fulfill()
+                        switch result {
+                        case .success(let returnedMovie):
+                            XCTAssertEqual(movie, returnedMovie)
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+                        expectation.fulfill()
 
-               }
+                    }
+
+                }
 
             case .failure(let error):
                 print(error)
@@ -241,21 +248,23 @@ class DocumentsTests: XCTestCase {
 
                 XCTAssertEqual(Update(updateId: 0), update)
 
-                Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDocument(
-                    UID: self.uid,
-                    identifier: "10"
-                ) { (result: Result<Movie, Swift.Error>) in
+                    self.client.getDocument(
+                        UID: self.uid,
+                        identifier: "10"
+                    ) { (result: Result<Movie, Swift.Error>) in
 
-                    switch result {
-                    case .success(let returnedMovie):
-                        XCTAssertEqual(movie, returnedMovie)
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        switch result {
+                        case .success(let returnedMovie):
+                            XCTAssertEqual(movie, returnedMovie)
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+                        expectation.fulfill()
+
                     }
-                    expectation.fulfill()
 
                 }
 
@@ -291,22 +300,24 @@ class DocumentsTests: XCTestCase {
 
                 XCTAssertEqual(Update(updateId: 0), update)
 
-                Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDocument(
-                    UID: self.uid,
-                    identifier: "\(identifier)"
-                ) { (result: Result<Movie, Swift.Error>) in
+                    self.client.getDocument(
+                        UID: self.uid,
+                        identifier: "\(identifier)"
+                    ) { (result: Result<Movie, Swift.Error>) in
 
-                    switch result {
-                    case .success(let returnedMovie):
-                        XCTAssertEqual(movie, returnedMovie)
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        switch result {
+                        case .success(let returnedMovie):
+                            XCTAssertEqual(movie, returnedMovie)
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
+                        expectation.fulfill()
                     }
 
-                    expectation.fulfill()
                 }
 
             case .failure(let error):
@@ -380,45 +391,52 @@ class DocumentsTests: XCTestCase {
         ) { result in
             switch result {
             case .success(let update):
+
                 XCTAssertEqual(Update(updateId: 0), update)
-                expectation.fulfill()
+
+                waitForPendingUpdate(self.client, self.uid, update) {
+
+                    self.client.deleteAllDocuments(UID: self.uid) { (result: Result<Update, Swift.Error>) in
+                        switch result {
+                        case .success(let update):
+
+                            XCTAssertEqual(Update(updateId: 1), update)
+
+                            waitForPendingUpdate(self.client, self.uid, update) {
+
+                                self.client.getDocuments(
+                                    UID: self.uid,
+                                    limit: 20
+                                ) { (result: Result<[Movie], Swift.Error>) in
+                                    switch result {
+                                    case .success(let results):
+                                        XCTAssertEqual([], results)
+                                        expectation.fulfill()
+                                    case .failure(let error):
+                                        print(error)
+                                        XCTFail()
+                                        expectation.fulfill()
+                                    }
+                                }
+
+                            }
+
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                            expectation.fulfill()
+                        }
+                    }
+
+                }
+                
             case .failure:
                 XCTFail("Failed to add or replace Movies document")
-            }
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-
-        let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
-        self.client.deleteAllDocuments(UID: uid) { (result: Result<Update, Swift.Error>) in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 1), update)
-                deleteExpectation.fulfill()
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-        self.wait(for: [deleteExpectation], timeout: 3.0)
-
-        Thread.sleep(forTimeInterval: 1.0)
-
-        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
-        self.client.getDocuments(
-            UID: self.uid,
-            limit: 20
-        ) { (result: Result<[Movie], Swift.Error>) in
-            switch result {
-            case .success(let results):
-                XCTAssertEqual([], results)
-                getExpectation.fulfill()
-            case .failure(let error):
-                print(error)
-                XCTFail()
+                expectation.fulfill()
             }
         }
 
-        self.wait(for: [getExpectation], timeout: 3.0)
+        self.wait(for: [expectation], timeout: 10.0)
     }
 
     func testDeleteBatchDocuments() {
@@ -439,39 +457,43 @@ class DocumentsTests: XCTestCase {
 
                 XCTAssertEqual(Update(updateId: 0), update)
 
-                Thread.sleep(forTimeInterval: 1.0)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                let idsToDelete: [Int] = [2, 1, 4]
+                    let idsToDelete: [Int] = [2, 1, 4]
 
-                self.client.deleteBatchDocuments(UID: self.uid, documentsUID: idsToDelete) { (result: Result<Update, Swift.Error>) in
-                    switch result {
+                    self.client.deleteBatchDocuments(UID: self.uid, documentsUID: idsToDelete) { (result: Result<Update, Swift.Error>) in
+                        switch result {
 
-                    case .success(let update):
+                        case .success(let update):
 
-                        XCTAssertEqual(Update(updateId: 1), update)
+                            XCTAssertEqual(Update(updateId: 1), update)
 
-                        Thread.sleep(forTimeInterval: 1.0)
+                            waitForPendingUpdate(self.client, self.uid, update) {
 
-                        self.client.getDocuments(
-                            UID: self.uid,
-                            limit: 20
-                        ) { (result: Result<[Movie], Swift.Error>) in
-                            switch result {
-                            case .success(let results):
-                                let filteredMovies: [Movie] = movies.filter { (movie: Movie) in !idsToDelete.contains(movie.id) }
-                                XCTAssertEqual(filteredMovies, results)
-                                expectation.fulfill()
-                            case .failure(let error):
-                                print(error)
-                                XCTFail()
+                                self.client.getDocuments(
+                                    UID: self.uid,
+                                    limit: 20
+                                ) { (result: Result<[Movie], Swift.Error>) in
+                                    switch result {
+                                    case .success(let results):
+                                        let filteredMovies: [Movie] = movies.filter { (movie: Movie) in !idsToDelete.contains(movie.id) }
+                                        XCTAssertEqual(filteredMovies, results)
+                                        expectation.fulfill()
+                                    case .failure(let error):
+                                        print(error)
+                                        XCTFail()
+                                    }
+                                }
+
                             }
-                        }
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
-                        expectation.fulfill()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                            expectation.fulfill()
+                        }
                     }
+
                 }
 
             case .failure:

--- a/Tests/MeiliSearchIntegrationTests/Pooling.swift
+++ b/Tests/MeiliSearchIntegrationTests/Pooling.swift
@@ -6,29 +6,57 @@
 //
 
 import Foundation
+import XCTest
 @testable import MeiliSearch
 
 public func pool(_ client: MeiliSearch) {
 
-    let semaphore = DispatchSemaphore(value: 1)
-    var success: Bool = false
+    autoreleasepool {
 
-    while true {
-        client.health { result in
-            switch result {
-            case .success:
-                success = true
-            case .failure:
-                Thread.sleep(forTimeInterval: 0.5)
-                success = false
+        let semaphore = DispatchSemaphore(value: 0)
+        var success: Bool = false
+
+        while true {
+            client.health { result in
+                switch result {
+                case .success:
+                    success = true
+                case .failure:
+                    Thread.sleep(forTimeInterval: 0.5)
+                    success = false
+                }
+                semaphore.signal()
             }
-            semaphore.signal()
+            if !success {
+                semaphore.wait()
+                continue
+            }
+            break
         }
-        if !success {
-            semaphore.wait()
-            continue
-        }
-        break
+
     }
 
+}
+
+public func waitForPendingUpdate(
+    _ client: MeiliSearch,
+    _ UID: String,
+    _ update: Update,
+    _ completion: @escaping () -> Void) {
+    func request() {
+        client.getUpdate(UID: UID, update) { result in
+            switch result {
+            case .success(let updateResult):
+                if updateResult.status == Update.Status.processed {
+                    completion()
+                    return
+                }
+                request()
+            case .failure(let error):
+                print(error)
+                XCTFail()
+            }
+        }
+    }
+    request()
 }

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -36,7 +36,6 @@ class SettingsTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
 
         self.client.deleteIndex(UID: uid) { _ in
-            Thread.sleep(forTimeInterval: TimeInterval(0.1))
             self.client.getOrCreateIndex(UID: self.uid) { result in
                 switch result {
                 case .success:
@@ -93,22 +92,24 @@ class SettingsTests: XCTestCase {
 
         self.client.updateAttributesForFaceting(UID: self.uid, newAttributesForFaceting) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getAttributesForFaceting(UID: self.uid) { result in
+                    self.client.getAttributesForFaceting(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attributes):
+                        switch result {
+                        case .success(let attributes):
 
-                        XCTAssertEqual(newAttributesForFaceting, attributes)
+                            XCTAssertEqual(newAttributesForFaceting, attributes)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -129,21 +130,23 @@ class SettingsTests: XCTestCase {
         self.client.resetAttributesForFaceting(UID: self.uid) { result in
 
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getAttributesForFaceting(UID: self.uid) { result in
+                    self.client.getAttributesForFaceting(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attributes):
+                        switch result {
+                        case .success(let attributes):
 
-                        XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -190,22 +193,23 @@ class SettingsTests: XCTestCase {
 
         self.client.updateDisplayedAttributes(UID: self.uid, newDisplayedAttributes) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDisplayedAttributes(UID: self.uid) { result in
+                    self.client.getDisplayedAttributes(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attributes):
+                        switch result {
+                        case .success(let attributes):
 
-                        XCTAssertEqual(newDisplayedAttributes, attributes)
+                            XCTAssertEqual(newDisplayedAttributes, attributes)
+                            expectation.fulfill()
 
-                        expectation.fulfill()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
                     }
 
                 }
@@ -226,21 +230,23 @@ class SettingsTests: XCTestCase {
         self.client.resetDisplayedAttributes(UID: self.uid) { result in
 
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDisplayedAttributes(UID: self.uid) { result in
+                    self.client.getDisplayedAttributes(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attribute):
+                        switch result {
+                        case .success(let attribute):
 
-                        XCTAssertEqual(self.defaultDisplayedAttributes, attribute)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultDisplayedAttributes, attribute)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -287,22 +293,24 @@ class SettingsTests: XCTestCase {
 
         self.client.updateDistinctAttribute(UID: self.uid, newDistinctAttribute) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDistinctAttribute(UID: self.uid) { result in
+                    self.client.getDistinctAttribute(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attribute):
+                        switch result {
+                        case .success(let attribute):
 
-                        XCTAssertEqual(newDistinctAttribute, attribute)
+                            XCTAssertEqual(newDistinctAttribute, attribute)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -324,22 +332,24 @@ class SettingsTests: XCTestCase {
         self.client.resetDistinctAttribute(UID: self.uid) { result in
 
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getDistinctAttribute(UID: self.uid) { result in
+                    self.client.getDistinctAttribute(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let attribute):
+                        switch result {
+                        case .success(let attribute):
 
-                        XCTAssertEqual(self.defaultDistinctAttribute, attribute)
+                            XCTAssertEqual(self.defaultDistinctAttribute, attribute)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -388,22 +398,24 @@ class SettingsTests: XCTestCase {
 
         self.client.updateRankingRules(UID: self.uid, newRankingRules) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getRankingRules(UID: self.uid) { result in
+                    self.client.getRankingRules(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let rankingRules):
+                        switch result {
+                        case .success(let rankingRules):
 
-                        XCTAssertEqual(newRankingRules, rankingRules)
+                            XCTAssertEqual(newRankingRules, rankingRules)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -424,21 +436,23 @@ class SettingsTests: XCTestCase {
         self.client.resetRankingRules(UID: self.uid) { result in
 
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getRankingRules(UID: self.uid) { result in
+                    self.client.getRankingRules(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let rankingRules):
+                        switch result {
+                        case .success(let rankingRules):
 
-                        XCTAssertEqual(self.defaultRankingRules, rankingRules)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultRankingRules, rankingRules)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -486,22 +500,24 @@ class SettingsTests: XCTestCase {
 
         self.client.updateSearchableAttributes(UID: self.uid, newSearchableAttributes) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSearchableAttributes(UID: self.uid) { result in
+                    self.client.getSearchableAttributes(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let searchableAttributes):
+                        switch result {
+                        case .success(let searchableAttributes):
 
-                        XCTAssertEqual(newSearchableAttributes, searchableAttributes)
+                            XCTAssertEqual(newSearchableAttributes, searchableAttributes)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -523,21 +539,23 @@ class SettingsTests: XCTestCase {
         self.client.resetSearchableAttributes(UID: self.uid) { result in
 
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSearchableAttributes(UID: self.uid) { result in
+                    self.client.getSearchableAttributes(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let searchableAttributes):
+                        switch result {
+                        case .success(let searchableAttributes):
 
-                        XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -581,22 +599,24 @@ class SettingsTests: XCTestCase {
 
         self.client.updateStopWords(UID: self.uid, newStopWords) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getStopWords(UID: self.uid) { result in
+                    self.client.getStopWords(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let finalStopWords):
+                        switch result {
+                        case .success(let finalStopWords):
 
-                        XCTAssertEqual(newStopWords, finalStopWords)
+                            XCTAssertEqual(newStopWords, finalStopWords)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -617,20 +637,22 @@ class SettingsTests: XCTestCase {
 
         self.client.resetStopWords(UID: self.uid) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getStopWords(UID: self.uid) { result in
+                    self.client.getStopWords(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let stopWords):
-                        XCTAssertEqual(self.defaultStopWords, stopWords)
-                        expectation.fulfill()
+                        switch result {
+                        case .success(let stopWords):
+                            XCTAssertEqual(self.defaultStopWords, stopWords)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -679,23 +701,25 @@ class SettingsTests: XCTestCase {
 
         self.client.updateSynonyms(UID: self.uid, newSynonyms) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSynonyms(UID: self.uid) { result in
+                    self.client.getSynonyms(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let updatedSynonyms):
+                        switch result {
+                        case .success(let updatedSynonyms):
 
-                        let rhs = Array(updatedSynonyms.keys).sorted(by: <)
-                        XCTAssertEqual(Array(newSynonyms.keys).sorted(by: <), rhs)
+                            let rhs = Array(updatedSynonyms.keys).sorted(by: <)
+                            XCTAssertEqual(Array(newSynonyms.keys).sorted(by: <), rhs)
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -715,21 +739,23 @@ class SettingsTests: XCTestCase {
 
         self.client.resetSynonyms(UID: self.uid) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSynonyms(UID: self.uid) { result in
+                    self.client.getSynonyms(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let synonyms):
+                        switch result {
+                        case .success(let synonyms):
 
-                        XCTAssertEqual(self.defaultSynonyms, synonyms)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultSynonyms, synonyms)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -779,27 +805,29 @@ class SettingsTests: XCTestCase {
 
         self.client.updateSetting(UID: self.uid, newSettings) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: 0.5)
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSetting(UID: self.uid) { result in
+                    self.client.getSetting(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let finalSetting):
+                        switch result {
+                        case .success(let finalSetting):
 
-                        XCTAssertEqual(newSettings.rankingRules.sorted(), finalSetting.rankingRules.sorted())
-                        XCTAssertEqual(newSettings.searchableAttributes.sorted(), finalSetting.searchableAttributes.sorted())
-                        XCTAssertEqual(newSettings.displayedAttributes.sorted(), finalSetting.displayedAttributes.sorted())
-                        XCTAssertEqual(newSettings.stopWords.sorted(), finalSetting.stopWords.sorted())
-                        XCTAssertEqual(newSettings.attributesForFaceting, finalSetting.attributesForFaceting)
-                        XCTAssertEqual(Array(newSettings.synonyms.keys).sorted(by: <), Array(finalSetting.synonyms.keys).sorted(by: <))
+                            XCTAssertEqual(newSettings.rankingRules.sorted(), finalSetting.rankingRules.sorted())
+                            XCTAssertEqual(newSettings.searchableAttributes.sorted(), finalSetting.searchableAttributes.sorted())
+                            XCTAssertEqual(newSettings.displayedAttributes.sorted(), finalSetting.displayedAttributes.sorted())
+                            XCTAssertEqual(newSettings.stopWords.sorted(), finalSetting.stopWords.sorted())
+                            XCTAssertEqual(newSettings.attributesForFaceting, finalSetting.attributesForFaceting)
+                            XCTAssertEqual(Array(newSettings.synonyms.keys).sorted(by: <), Array(finalSetting.synonyms.keys).sorted(by: <))
 
-                        expectation.fulfill()
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }
@@ -820,21 +848,23 @@ class SettingsTests: XCTestCase {
 
         self.client.resetSetting(UID: self.uid) { result in
             switch result {
-            case .success:
+            case .success(let update):
 
-                Thread.sleep(forTimeInterval: TimeInterval(0.5))
+                waitForPendingUpdate(self.client, self.uid, update) {
 
-                self.client.getSetting(UID: self.uid) { result in
+                    self.client.getSetting(UID: self.uid) { result in
 
-                    switch result {
-                    case .success(let settings):
+                        switch result {
+                        case .success(let settings):
 
-                        XCTAssertEqual(self.defaultGlobalSettings, settings)
-                        expectation.fulfill()
+                            XCTAssertEqual(self.defaultGlobalSettings, settings)
+                            expectation.fulfill()
 
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
+                        case .failure(let error):
+                            print(error)
+                            XCTFail()
+                        }
+
                     }
 
                 }

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -72,7 +72,7 @@ class UpdatesTests: XCTestCase {
                     switch result {
                     case .success(let update):
                         XCTAssertEqual("DocumentsAddition", update.type.name)
-                        XCTAssertTrue(update.type.number >= 0)
+                        XCTAssertTrue(update.type.number! >= 0)
                     case .failure(let error):
                         print(error)
                         XCTFail()
@@ -108,7 +108,7 @@ class UpdatesTests: XCTestCase {
             case .success(let updates):
                 updates.forEach { (update: Update.Result) in
                   XCTAssertEqual("DocumentsAddition", update.type.name)
-                  XCTAssertTrue(update.type.number >= 0)
+                  XCTAssertTrue(update.type.number! >= 0)
                 }
 
             case .failure(let error):


### PR DESCRIPTION
This PR removes the usage of `Thread.sleep(timeInterval:)` included between async calls. I tried to implement a solution based on `DispatchSemaphore` but this turns out to be problematic when used inside closures and it was creating a [deadlock](https://stackoverflow.com/questions/37906509/ios-url-requests-semaphore-issues).