### PR TITLE
Error handler

### DIFF
--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -70,8 +70,11 @@ struct Indexes {
                 completion(.success(index))
 
             case .failure(let error):
+                print("ONETWOTREE")
+                print(error)
                 switch error {
-                case CreateError.indexAlreadyExists:
+
+                case CreateError.indexAlreadyExists: // "index already exists" should be used using error.errorCode
                     self.get(UID, completion)
                 default:
                     completion(.failure(error))

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -213,26 +213,17 @@ public enum CreateError: Swift.Error, Equatable {
     // MARK: Codable
 
     static func decode(_ error: MSError) -> Swift.Error {
-
+        // print("CREATE ERROR")
+        // print(error)
         let underlyingError: NSError = error.underlying as NSError
-
-        if let data = error.data {
-
-            let msErrorResponse: MSErrorResponse?
-            do {
-                let decoder: JSONDecoder = JSONDecoder()
-                msErrorResponse = try decoder.decode(MSErrorResponse.self, from: data)
-            } catch {
-                msErrorResponse = nil
-            }
-
-            if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
+        // print(underlyingError)
+        if let msErrorResponse: MSErrorResponse = error.data {
+            if underlyingError.code == 400 && msErrorResponse.errorType == "invalid_request_error" && msErrorResponse.errorCode == "index_already_exists" {
                 return CreateError.indexAlreadyExists
             }
             return error
 
         }
-
         return error
     }
 }

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -213,10 +213,7 @@ public enum CreateError: Swift.Error, Equatable {
     // MARK: Codable
 
     static func decode(_ error: MSError) -> Swift.Error {
-        // print("CREATE ERROR")
-        // print(error)
         let underlyingError: NSError = error.underlying as NSError
-        // print(underlyingError)
         if let msErrorResponse: MSErrorResponse = error.data {
             if underlyingError.code == 400 && msErrorResponse.errorType == "invalid_request_error" && msErrorResponse.errorCode == "index_already_exists" {
                 return CreateError.indexAlreadyExists

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -132,6 +132,7 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
+                print(data)
                 if data != nil {
                     let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
                     completion(.failure(

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -21,8 +21,10 @@ public protocol URLSessionDataTaskProtocol {
     func resume()
 }
 
+// struct meiliSearchApiError: Codable
+
 struct MSError: Swift.Error {
-    let data: Data?
+    let data: MSErrorResponse?
     let underlying: Swift.Error
 }
 
@@ -77,10 +79,19 @@ final class Request {
                 }
 
                 if 400 ... 599 ~= response.statusCode {
-                    completion(.failure(
-                      MSError(
-                        data: data,
-                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    if data != nil {
+                        let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                        completion(.failure(
+                            MSError(
+                            data: meiliSearchApiError,
+                            underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    }
+                    else {
+                        completion(.failure(
+                        MSError(
+                            data: nil,
+                            underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    }
                     return
                 }
 
@@ -111,7 +122,7 @@ final class Request {
         let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
 
             if let error: Swift.Error = error {
-                let msError = MSError(data: data, underlying: error)
+                let msError = MSError(data: nil, underlying: error)
                 completion(.failure(msError))
                 return
             }
@@ -121,10 +132,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -166,10 +186,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -205,10 +234,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 

--- a/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
@@ -1,0 +1,114 @@
+@testable import MeiliSearch
+import XCTest
+import Foundation
+
+private struct Movie: Codable, Equatable {
+
+    let id: Int
+    let title: String
+    let comment: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case comment
+    }
+
+    init(id: Int, title: String, comment: String? = nil) {
+        self.id = id
+        self.title = title
+        self.comment = comment
+    }
+
+}
+
+private let movies: [Movie] = [
+    Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
+    Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
+    Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
+    Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
+    Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
+    Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
+    Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
+    Movie(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo")
+]
+
+class ErrorsTests: XCTestCase {
+
+    private var client: MeiliSearch!
+    private let uid: String = "books_test"
+
+    override func setUp() {
+        super.setUp()
+
+        if client == nil {
+            client = try! MeiliSearch(
+              Config.default(apiKey: "masterKey"))
+        }
+
+        pool(client)
+
+        let expectation = XCTestExpectation(description: "Create index if it does not exist")
+
+        self.client.deleteIndex(UID: uid) { _ in
+            self.client.getOrCreateIndex(UID: self.uid) { result in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    print(error)
+                }
+                expectation.fulfill()
+            }
+        }
+
+        self.wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testGetDocumentThatDoesNotExistAndFail() {
+
+        let getExpectation = XCTestExpectation(description: "Get one document and fail")
+        self.client.getDocument(
+            UID: self.uid,
+            identifier: "123456"
+        ) { (result: Result<Movie, Swift.Error>) in
+            switch result {
+            case .success:
+                XCTFail("Document has been found while it should not have")
+            case .failure(let error):
+                print(error) // Outputs the following
+                /*
+                    MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "Document with id 123456 not found", errorCode: "document_not_found", errorType: "invalid_request_error", errorLink: Optional("https://docs.meilisearch.com/errors#document_not_found"))), underlying: Error Domain=HttpStatus Code=404 "(null)")
+                */
+                XCTAssertEqual("document_not_found", error.errorCode) // How do I say that error is a MSError ?
+                getExpectation.fulfill()
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+
+    func testCreateSameIndexTwiceAndFail() {
+        // "index already exists" shoudl be used using error.errorCode
+        let createExpectation = XCTestExpectation(description: "Create same index twice")
+
+        self.client.createIndex(UID: self.uid) { result in
+            switch result {
+            case .success:
+                XCTFail("Create Index should not have worked")
+            case .failure(let error):
+                print(error)
+                // XCTAssertEqual("index_already_exists", error.)
+                createExpectation.fulfill()
+            }
+        }
+
+        self.wait(for: [createExpectation], timeout: 1.0)
+    }
+
+
+
+    static var allTests = [
+        ("testCreateSameIndexTwiceAndFail", testCreateSameIndexTwiceAndFail),
+    ]
+
+}

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -4,7 +4,6 @@ import XCTest
 class ClientTests: XCTestCase {
 
   func testValidHostURL() {
-    let client: MeiliSearch = try! MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey"))
     XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey")))
   }
 

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -4,6 +4,10 @@ import XCTest
 class ClientTests: XCTestCase {
 
   func testValidHostURL() {
+<<<<<<< HEAD:Tests/MeiliSearchUnitTests/ClientTests.swift
+=======
+    let client: MeiliSearch = try! MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey"))
+>>>>>>> 57d8160... Remove mock server from client tests:Tests/MeiliSearchTests/ClientTests.swift
     XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey")))
   }
 

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -4,10 +4,7 @@ import XCTest
 class ClientTests: XCTestCase {
 
   func testValidHostURL() {
-<<<<<<< HEAD:Tests/MeiliSearchUnitTests/ClientTests.swift
-=======
     let client: MeiliSearch = try! MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey"))
->>>>>>> 57d8160... Remove mock server from client tests:Tests/MeiliSearchTests/ClientTests.swift
     XCTAssertNotNil(try? MeiliSearch(Config(hostURL: "http://localhost:7700", apiKey: "masterKey")))
   }
 

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -22,11 +22,32 @@ class DocumentsTests: XCTestCase {
 
     private var client: MeiliSearch!
 
-    private let session = MockURLSession()
+    override class func setUp() { // 1.
+           super.setUp()
+        // TODO: add getOrCreateIndex in this method but it does not work
+    }
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: nil, session: session))
+        client = try! MeiliSearch(Config(hostURL: "http://localhost:7700"))
+
+        let expectation = XCTestExpectation(description: "Create index if it does not exist")
+
+        self.client.getOrCreateIndex(UID: "books_test") { result in
+            switch result {
+            case .success(let index):
+                print("INDEX")
+                print(index)
+                expectation.fulfill()
+            case .failure(let error):
+                print(error)
+                print("ERROR")
+//                XCTFail("Failed to create Index")
+                expectation.fulfill()
+            }
+        }
+        self.wait(for: [expectation], timeout: 2.0)
+
     }
 
     func testAddDocuments() {
@@ -41,11 +62,9 @@ class DocumentsTests: XCTestCase {
         let jsonData = jsonString.data(using: .utf8)!
         let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString, code: 202)
-
         // Start the test with the mocked server
 
-        let uid: String = "Movies"
+        let uid: String = "books_test"
 
         let documentJsonString = """
         [{
@@ -82,257 +101,247 @@ class DocumentsTests: XCTestCase {
 
     }
 
-    func testUpdateDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-
-        let documentJsonString = """
-        [{
-            "id": 287947,
-            "title": "Shazam ⚡️"
-        }]
-        """
-
-        let primaryKey: String = "movieskud"
-
-        let documents: Data = documentJsonString.data(using: .utf8)!
-
-        let expectation = XCTestExpectation(description: "Add or update Movies document")
-
-        self.client.updateDocuments(
-            UID: uid,
-            documents: documents,
-            primaryKey: primaryKey) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or update Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testGetDocument() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {
-            "id": 25684,
-            "title": "American Ninja 5",
-            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-            "release_date": "2020-04-04T19:59:49.259572Z"
-        }
-        """
-
-        session.pushData(jsonString, code: 200)
-
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-        let identifier: String = "25684"
-
-        let expectation = XCTestExpectation(description: "Get Movies document")
-
-      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
-
-            switch result {
-            case .success(let movie):
-                XCTAssertEqual(stubMovie, movie)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies document")
-            }
-
-      }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testGetDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        [{
-            "id": 25684,
-            "release_date": "2020-04-04T19:59:49.259572Z",
-            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-            "title": "American Ninja 5",
-            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
-        },{
-            "id": 468219,
-            "title": "Dead in a Week (Or Your Money Back)",
-            "release_date": "2020-04-04T19:59:49.259572Z",
-            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
-        }]
-        """
-
-        session.pushData(jsonString, code: 200)
-
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-        let limit: Int = 10
-
-        let expectation = XCTestExpectation(description: "Get Movies documents")
-
-        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
-
-            switch result {
-            case .success(let movies):
-                XCTAssertEqual(stubMovies, movies)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteDocument() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let identifier: String = "25684"
-
-        let expectation = XCTestExpectation(description: "Delete Movies document")
-
-        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteAllDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-        self.client.deleteAllDocuments(UID: uid) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteBatchDocuments() {
-
-        //Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
-      }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
+//    func testUpdateDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//
+//        let documentJsonString = """
+//        [{
+//            "id": 287947,
+//            "title": "Shazam ⚡️"
+//        }]
+//        """
+//
+//        let primaryKey: String = "movieskud"
+//
+//        let documents: Data = documentJsonString.data(using: .utf8)!
+//
+//        let expectation = XCTestExpectation(description: "Add or update Movies document")
+//
+//        self.client.updateDocuments(
+//            UID: uid,
+//            documents: documents,
+//            primaryKey: primaryKey) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to add or update Movies document")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testGetDocument() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {
+//            "id": 25684,
+//            "title": "American Ninja 5",
+//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
+//            "release_date": "2020-04-04T19:59:49.259572Z"
+//        }
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+//        let data = jsonString.data(using: .utf8)!
+//        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//        let identifier: String = "25684"
+//
+//        let expectation = XCTestExpectation(description: "Get Movies document")
+//
+//      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
+//
+//            switch result {
+//            case .success(let movie):
+//                XCTAssertEqual(stubMovie, movie)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to get Movies document")
+//            }
+//
+//      }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testGetDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        [{
+//            "id": 25684,
+//            "release_date": "2020-04-04T19:59:49.259572Z",
+//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+//            "title": "American Ninja 5",
+//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
+//        },{
+//            "id": 468219,
+//            "title": "Dead in a Week (Or Your Money Back)",
+//            "release_date": "2020-04-04T19:59:49.259572Z",
+//            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
+//            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
+//        }]
+//        """
+//
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+//        let data = jsonString.data(using: .utf8)!
+//        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
+//
+//        // Start the test with the mocked server
+//
+//        let uid: String = "books_test"
+//        let limit: Int = 10
+//
+//        let expectation = XCTestExpectation(description: "Get Movies documents")
+//
+//        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
+//
+//            switch result {
+//            case .success(let movies):
+//                XCTAssertEqual(stubMovies, movies)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to get Movies documents")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteDocument() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let identifier: String = "25684"
+//
+//        let expectation = XCTestExpectation(description: "Delete Movies document")
+//
+//        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete Movies document")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteAllDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
+//
+//        self.client.deleteAllDocuments(UID: uid) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete all Movies documents")
+//            }
+//
+//        }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
+//
+//    func testDeleteBatchDocuments() {
+//
+//        //Prepare the mock server
+//
+//        let jsonString = """
+//        {"updateId":0}
+//        """
+//
+//        let decoder: JSONDecoder = JSONDecoder()
+//        let jsonData = jsonString.data(using: .utf8)!
+//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+//
+//        // Start the test with the mocked server
+//
+//        let uid = "books_test"
+//        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
+//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
+//
+//      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
+//
+//            switch result {
+//            case .success(let update):
+//                XCTAssertEqual(stubUpdate, update)
+//                expectation.fulfill()
+//            case .failure:
+//                XCTFail("Failed to delete all Movies documents")
+//            }
+//
+//      }
+//
+//        self.wait(for: [expectation], timeout: 1.0)
+//
+//    }
 
     private func convertToDictionary(_ string: String) -> [String: Any] {
         if let data: Data = string.data(using: .utf8) {
@@ -358,12 +367,12 @@ class DocumentsTests: XCTestCase {
 
     static var allTests = [
         ("testAddDocuments", testAddDocuments),
-        ("testUpdateDocuments", testUpdateDocuments),
-        ("testGetDocument", testGetDocument),
-        ("testGetDocuments", testGetDocuments),
-        ("testDeleteDocument", testDeleteDocument),
-        ("testDeleteAllDocuments", testDeleteAllDocuments),
-        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
+//        ("testUpdateDocuments", testUpdateDocuments),
+//        ("testGetDocument", testGetDocument),
+//        ("testGetDocuments", testGetDocuments),
+//        ("testDeleteDocument", testDeleteDocument),
+//        ("testDeleteAllDocuments", testDeleteAllDocuments),
+//        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
     ]
 
 }

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -29,7 +29,10 @@ class DocumentsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        client = try! MeiliSearch(Config(hostURL: "http://localhost:7700"))
+
+        if client == nil {
+            client = try! MeiliSearch(Config.default)
+        }
 
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
 

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -6,17 +6,71 @@ private struct Movie: Codable, Equatable {
 
     let id: Int
     let title: String
-    let overview: String
-    let releaseDate: Date
+    let comment: String?
 
     enum CodingKeys: String, CodingKey {
         case id
         case title
-        case overview
-        case releaseDate = "release_date"
+        case comment
+    }
+    init(id: Int, title: String, comment: String? = nil) {
+        self.id = id
+        self.title = title
+        self.comment = comment
     }
 
 }
+
+private let movies = [
+    Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
+    Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
+    Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
+    Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
+    Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
+    Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
+    Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
+
+]
+let documentJsonString = """
+[
+    {
+        "id": 123,
+        "title": "Pride and Prejudice",
+        "comment": "A great book"
+    },
+    {
+        "id": 456,
+        "title": "Le Petit Prince",
+        "comment": "A french book"
+    },
+    {
+        "id": 2,
+        "title": "Le Rouge et le Noir",
+        "comment": "Another french book"
+    },
+    {
+        "id": 1,
+        "title": "Alice In Wonderland",
+        "comment": "A weird book"
+    },
+    {
+        "id": 1344,
+        "title": "The Hobbit",
+        "comment": "An awesome book"
+    },
+    {
+        "id": 4,
+        "title": "Harry Potter and the Half-Blood Prince",
+        "comment": "The best book"
+    },
+    {
+        "id": 42,
+        "title": "The Hitchhiker's Guide to the Galaxy"
+    }
+]
+"""
+
+let uid: String = "books_test"
 
 class DocumentsTests: XCTestCase {
 
@@ -33,318 +87,204 @@ class DocumentsTests: XCTestCase {
         if client == nil {
             client = try! MeiliSearch(Config.default)
         }
-
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.getOrCreateIndex(UID: "books_test") { result in
+        self.client.deleteIndex(UID: uid) { result in
             switch result {
-            case .success(let index):
-                print("INDEX")
-                print(index)
-                expectation.fulfill()
-            case .failure(let error):
-                print(error)
-                print("ERROR")
-//                XCTFail("Failed to create Index")
+            case .success:
+                print("Index deleted")
+                self.client.getOrCreateIndex(UID: uid) { result in
+                    switch result {
+                    case .success:
+                        print("Index Created")
+                        expectation.fulfill()
+                    case .failure(let error):
+                        print(error)
+                        expectation.fulfill()
+                    }
+                }
+            case .failure:
                 expectation.fulfill()
             }
         }
-        self.wait(for: [expectation], timeout: 2.0)
 
+        self.wait(for: [expectation], timeout: 2.0)
     }
 
-    func testAddDocuments() {
+    func testAddAndGetDocuments() {
+        let documents: Data = try! JSONEncoder().encode(movies)
 
-        //Prepare the mock server
+        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.addDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Failed to add or replace Movies document")
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.getDocuments(
+            UID: uid,
+            limit: 20
+        ) { (result: Result<[Movie], Swift.Error>) in
 
-        let jsonString = """
-        {"updateId":0}
-        """
+            switch result {
+            case .success(let returnedMovies):
+                print("HELLO")
+                print(returnedMovies)
+                XCTAssertEqual(movies, returnedMovies)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        // Start the test with the mocked server
-
-        let uid: String = "books_test"
-
-        let documentJsonString = """
-        [{
-            "id": 287947,
-            "title": "Shazam",
-            "poster": "https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg",
-            "overview": "A boy is given the ability to become an adult superhero in times of need with a single magic word.",
-            "release_date": "2019-03-23"
-        }]
-        """
-
-        let primaryKey: String = ""
-
-        let documents: Data = documentJsonString.data(using: .utf8)!
+    func testAddAndGetOneDocuments() {
+        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+        let documents: Data = try! JSONEncoder().encode([movie])
+//        print(jsonData)
+//        let documents: Data = documentJsonString.data(using: .utf8)!
+//        let jsonString = String(data: jsonData, encoding: .utf8)!
+//        print(jsonString)
+//        let documents: Data = jsonString.data(using: .utf8)!
+//        print(jsonString)
 
         let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
         self.client.addDocuments(
             UID: uid,
             documents: documents,
-            primaryKey: primaryKey) { result in
-
+            primaryKey: nil
+        ) { result in
             switch result {
             case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+
+            switch result {
+            case .success(let returnedMovie):
+                print("HELLO")
+                print(returnedMovie)
+                XCTAssertEqual(movie, returnedMovie)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+
+    func testUpdateAndGetDocuments() {
+        // FAILS
+        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+        let documents: Data = try! JSONEncoder().encode([movie])
+
+        let expectation = XCTestExpectation(description: "Add or update Movies document")
+
+        self.client.updateDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+
+            switch result {
+            case .success(let returnedMovie):
+                print("HELLO")
+                print(returnedMovie)
+                XCTAssertEqual(movie, returnedMovie)
+                getExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+
+    func testDeleteOneDocument(){
+        let documents: Data = try! JSONEncoder().encode(movies)
+
+        let expectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.addDocuments(
+            UID: uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
                 expectation.fulfill()
             case .failure:
                 XCTFail("Failed to add or replace Movies document")
             }
-
         }
-
         self.wait(for: [expectation], timeout: 1.0)
+        sleep(1)
+        let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.deleteDocument(UID: uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 1), update)
+                deleteExpectation.fulfill()
+            case .failure(let error):
+                XCTFail(error.localizedDescription)
+            }
+        }
+        self.wait(for: [deleteExpectation], timeout: 3.0)
+
+        sleep(1)
+        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+        self.client.getDocument(
+            UID: uid,
+            identifier: "10"
+        ) { (result: Result<Movie, Swift.Error>) in
+            switch result {
+            case .success:
+                XCTFail("Movie should not exist")
+            case .failure(let error):
+                // How can I get information from the error
+//                print(underlyingError.HttpStatus)
+                getExpectation.fulfill()
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+
 
     }
-
-//    func testUpdateDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//
-//        let documentJsonString = """
-//        [{
-//            "id": 287947,
-//            "title": "Shazam ⚡️"
-//        }]
-//        """
-//
-//        let primaryKey: String = "movieskud"
-//
-//        let documents: Data = documentJsonString.data(using: .utf8)!
-//
-//        let expectation = XCTestExpectation(description: "Add or update Movies document")
-//
-//        self.client.updateDocuments(
-//            UID: uid,
-//            documents: documents,
-//            primaryKey: primaryKey) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to add or update Movies document")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testGetDocument() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {
-//            "id": 25684,
-//            "title": "American Ninja 5",
-//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-//            "release_date": "2020-04-04T19:59:49.259572Z"
-//        }
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-//        let data = jsonString.data(using: .utf8)!
-//        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//        let identifier: String = "25684"
-//
-//        let expectation = XCTestExpectation(description: "Get Movies document")
-//
-//      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
-//
-//            switch result {
-//            case .success(let movie):
-//                XCTAssertEqual(stubMovie, movie)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to get Movies document")
-//            }
-//
-//      }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testGetDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        [{
-//            "id": 25684,
-//            "release_date": "2020-04-04T19:59:49.259572Z",
-//            "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-//            "title": "American Ninja 5",
-//            "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
-//        },{
-//            "id": 468219,
-//            "title": "Dead in a Week (Or Your Money Back)",
-//            "release_date": "2020-04-04T19:59:49.259572Z",
-//            "poster": "https://image.tmdb.org/t/p/w1280/f4ANVEuEaGy2oP5M0Y2P1dwxUNn.jpg",
-//            "overview": "William has failed to kill himself so many times that he outsources his suicide to aging assassin Leslie. But with the contract signed and death assured within a week (or his money back), William suddenly discovers reasons to live... However Leslie is under pressure from his boss to make sure the contract is completed."
-//        }]
-//        """
-//
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-//        let data = jsonString.data(using: .utf8)!
-//        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
-//
-//        // Start the test with the mocked server
-//
-//        let uid: String = "books_test"
-//        let limit: Int = 10
-//
-//        let expectation = XCTestExpectation(description: "Get Movies documents")
-//
-//        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
-//
-//            switch result {
-//            case .success(let movies):
-//                XCTAssertEqual(stubMovies, movies)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to get Movies documents")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteDocument() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let identifier: String = "25684"
-//
-//        let expectation = XCTestExpectation(description: "Delete Movies document")
-//
-//        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete Movies document")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteAllDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-//
-//        self.client.deleteAllDocuments(UID: uid) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete all Movies documents")
-//            }
-//
-//        }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
-//
-//    func testDeleteBatchDocuments() {
-//
-//        //Prepare the mock server
-//
-//        let jsonString = """
-//        {"updateId":0}
-//        """
-//
-//        let decoder: JSONDecoder = JSONDecoder()
-//        let jsonData = jsonString.data(using: .utf8)!
-//        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-//
-//        // Start the test with the mocked server
-//
-//        let uid = "books_test"
-//        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
-//        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-//
-//      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
-//
-//            switch result {
-//            case .success(let update):
-//                XCTAssertEqual(stubUpdate, update)
-//                expectation.fulfill()
-//            case .failure:
-//                XCTFail("Failed to delete all Movies documents")
-//            }
-//
-//      }
-//
-//        self.wait(for: [expectation], timeout: 1.0)
-//
-//    }
 
     private func convertToDictionary(_ string: String) -> [String: Any] {
         if let data: Data = string.data(using: .utf8) {
@@ -369,10 +309,10 @@ class DocumentsTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testAddDocuments", testAddDocuments),
-//        ("testUpdateDocuments", testUpdateDocuments),
-//        ("testGetDocument", testGetDocument),
-//        ("testGetDocuments", testGetDocuments),
+        ("testAddAndGetDocuments", testAddAndGetDocuments),
+        ("testAddAndGetOneDocuments", testAddAndGetOneDocuments),
+        ("testUpdateAndGetDocuments", testUpdateAndGetDocuments),
+        ("testDeleteOneDocument", testDeleteOneDocument)
 //        ("testDeleteDocument", testDeleteDocument),
 //        ("testDeleteAllDocuments", testDeleteAllDocuments),
 //        ("testDeleteBatchDocuments", testDeleteBatchDocuments)

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -123,7 +123,8 @@ class DocumentsTests: XCTestCase {
             case .success(let update):
                 XCTAssertEqual(Update(updateId: 0), update)
                 expectation.fulfill()
-            case .failure:
+            case .failure(let error):
+                print(error)
                 XCTFail("Failed to add or replace Movies document")
             }
         }
@@ -137,8 +138,6 @@ class DocumentsTests: XCTestCase {
 
             switch result {
             case .success(let returnedMovies):
-                print("HELLO")
-                print(returnedMovies)
                 XCTAssertEqual(movies, returnedMovies)
                 getExpectation.fulfill()
             case .failure(let error):
@@ -151,12 +150,6 @@ class DocumentsTests: XCTestCase {
     func testAddAndGetOneDocuments() {
         let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
         let documents: Data = try! JSONEncoder().encode([movie])
-//        print(jsonData)
-//        let documents: Data = documentJsonString.data(using: .utf8)!
-//        let jsonString = String(data: jsonData, encoding: .utf8)!
-//        print(jsonString)
-//        let documents: Data = jsonString.data(using: .utf8)!
-//        print(jsonString)
 
         let expectation = XCTestExpectation(description: "Add or replace Movies document")
 

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -92,7 +92,7 @@ class DocumentsTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
+//                XCTAssertEqual(stubUpdate, update)
                 expectation.fulfill()
             case .failure:
                 XCTFail("Failed to add or replace Movies document")

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -13,6 +13,7 @@ private struct Movie: Codable, Equatable {
         case title
         case comment
     }
+
     init(id: Int, title: String, comment: String? = nil) {
         self.id = id
         self.title = title
@@ -21,7 +22,7 @@ private struct Movie: Codable, Equatable {
 
 }
 
-private let movies = [
+private let movies: [Movie] = [
     Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
     Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
     Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
@@ -29,211 +30,256 @@ private let movies = [
     Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
     Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
     Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
-
+    Movie(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo")
 ]
-let documentJsonString = """
-[
-    {
-        "id": 123,
-        "title": "Pride and Prejudice",
-        "comment": "A great book"
-    },
-    {
-        "id": 456,
-        "title": "Le Petit Prince",
-        "comment": "A french book"
-    },
-    {
-        "id": 2,
-        "title": "Le Rouge et le Noir",
-        "comment": "Another french book"
-    },
-    {
-        "id": 1,
-        "title": "Alice In Wonderland",
-        "comment": "A weird book"
-    },
-    {
-        "id": 1344,
-        "title": "The Hobbit",
-        "comment": "An awesome book"
-    },
-    {
-        "id": 4,
-        "title": "Harry Potter and the Half-Blood Prince",
-        "comment": "The best book"
-    },
-    {
-        "id": 42,
-        "title": "The Hitchhiker's Guide to the Galaxy"
-    }
-]
-"""
-
-let uid: String = "books_test"
 
 class DocumentsTests: XCTestCase {
 
     private var client: MeiliSearch!
-
-    override class func setUp() { // 1.
-           super.setUp()
-        // TODO: add getOrCreateIndex in this method but it does not work
-    }
+    private let uid: String = "books_test"
 
     override func setUp() {
         super.setUp()
 
         if client == nil {
-            client = try! MeiliSearch(Config.default)
+            client = try! MeiliSearch(
+              Config.default(apiKey: "masterKey"))
         }
+
         let expectation = XCTestExpectation(description: "Create index if it does not exist")
-        self.client.deleteIndex(UID: uid) { result in
-            switch result {
-            case .success:
-                print("Index deleted")
-                self.client.getOrCreateIndex(UID: uid) { result in
-                    switch result {
-                    case .success:
-                        print("Index Created")
-                        expectation.fulfill()
-                    case .failure(let error):
-                        print(error)
-                        expectation.fulfill()
-                    }
+
+        self.client.deleteIndex(UID: uid) { _ in
+            self.client.getOrCreateIndex(UID: self.uid) { result in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    print(error)
                 }
-            case .failure:
                 expectation.fulfill()
             }
         }
 
-        self.wait(for: [expectation], timeout: 2.0)
+        self.wait(for: [expectation], timeout: 10.0)
     }
 
     func testAddAndGetDocuments() {
         let documents: Data = try! JSONEncoder().encode(movies)
 
         let expectation = XCTestExpectation(description: "Add or replace Movies document")
+
         self.client.addDocuments(
-            UID: uid,
+            UID: self.uid,
             documents: documents,
             primaryKey: nil
         ) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 0), update)
-                expectation.fulfill()
-            case .failure(let error):
-                print(error)
-                XCTFail("Failed to add or replace Movies document")
-            }
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-        sleep(1)
-        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
-        self.client.getDocuments(
-            UID: uid,
-            limit: 20
-        ) { (result: Result<[Movie], Swift.Error>) in
 
             switch result {
-            case .success(let returnedMovies):
-                XCTAssertEqual(movies, returnedMovies)
-                getExpectation.fulfill()
+            case .success(let update):
+
+                XCTAssertEqual(Update(updateId: 0), update)
+
+                Thread.sleep(forTimeInterval: 1.0)
+
+                self.client.getDocuments(
+                    UID: self.uid,
+                    limit: 20
+                ) { (result: Result<[Movie], Swift.Error>) in
+
+                    switch result {
+                    case .success(let returnedMovies):
+
+                        movies.forEach { (movie: Movie) in
+                            XCTAssertTrue(returnedMovies.contains(movie))
+                        }
+
+                    case .failure(let error):
+                        print(error)
+                        XCTFail()
+                    }
+
+                    expectation.fulfill()
+                }
+
             case .failure(let error):
-                XCTFail(error.localizedDescription)
+                print(error)
+                XCTFail()
+            }
+        }
+        self.wait(for: [expectation], timeout: 5.0)
+
+    }
+
+    func testGetOneDocumentAndFail() {
+
+        let getExpectation = XCTestExpectation(description: "Get one document and fail")
+        self.client.getDocument(
+            UID: self.uid,
+            identifier: "123456"
+        ) { (result: Result<Movie, Swift.Error>) in
+            switch result {
+            case .success:
+                XCTFail("Document has been found while it should not have")
+            case .failure:
+                getExpectation.fulfill()
             }
         }
         self.wait(for: [getExpectation], timeout: 3.0)
     }
 
-    func testAddAndGetOneDocuments() {
+    func testAddAndGetOneDocumentWithIntIdentifierAndSucceed() {
+
         let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
         let documents: Data = try! JSONEncoder().encode([movie])
 
         let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
         self.client.addDocuments(
-            UID: uid,
+            UID: self.uid,
             documents: documents,
             primaryKey: nil
         ) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 0), update)
-                expectation.fulfill()
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-        sleep(1)
-        let getExpectation = XCTestExpectation(description: "Add or replace Movies document")
-        self.client.getDocument(
-            UID: uid,
-            identifier: "10"
-        ) { (result: Result<Movie, Swift.Error>) in
 
             switch result {
-            case .success(let returnedMovie):
-                print("HELLO")
-                print(returnedMovie)
-                XCTAssertEqual(movie, returnedMovie)
-                getExpectation.fulfill()
+
+            case .success(let update):
+
+                XCTAssertEqual(Update(updateId: 0), update)
+
+                Thread.sleep(forTimeInterval: 1.0)
+
+               self.client.getDocument(
+                   UID: self.uid,
+                   identifier: 10
+               ) { (result: Result<Movie, Swift.Error>) in
+
+                   switch result {
+                   case .success(let returnedMovie):
+                       XCTAssertEqual(movie, returnedMovie)
+                   case .failure(let error):
+                       print(error)
+                       XCTFail()
+                   }
+                   expectation.fulfill()
+
+               }
+
             case .failure(let error):
-                XCTFail(error.localizedDescription)
+                print(error)
+                XCTFail()
+                expectation.fulfill()
             }
+
         }
-        self.wait(for: [getExpectation], timeout: 3.0)
+
+         self.wait(for: [expectation], timeout: 5.0)
+    }
+
+    func testAddAndGetOneDocuments() {
+
+        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+        let documents: Data = try! JSONEncoder().encode([movie])
+
+        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+
+        self.client.addDocuments(
+            UID: self.uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+
+            switch result {
+
+            case .success(let update):
+
+                XCTAssertEqual(Update(updateId: 0), update)
+
+                Thread.sleep(forTimeInterval: 1.0)
+
+               self.client.getDocument(
+                   UID: self.uid,
+                   identifier: "10"
+               ) { (result: Result<Movie, Swift.Error>) in
+
+                   switch result {
+                   case .success(let returnedMovie):
+                       XCTAssertEqual(movie, returnedMovie)
+                   case .failure(let error):
+                       print(error)
+                       XCTFail()
+                   }
+                   expectation.fulfill()
+
+               }
+
+            case .failure(let error):
+                print(error)
+                XCTFail()
+                expectation.fulfill()
+            }
+
+        }
+
+         self.wait(for: [expectation], timeout: 5.0)
     }
 
     func testUpdateAndGetDocuments() {
-        // FAILS
-        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+
+        let identifier: Int = 1844
+
+        let movie: Movie = movies.first(where: { (movie: Movie) in movie.id == identifier })!
         let documents: Data = try! JSONEncoder().encode([movie])
 
         let expectation = XCTestExpectation(description: "Add or update Movies document")
 
         self.client.updateDocuments(
-            UID: uid,
+            UID: self.uid,
             documents: documents,
             primaryKey: nil
         ) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 0), update)
-                expectation.fulfill()
-            case .failure(let error):
-                XCTFail(error.localizedDescription)
-            }
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-        sleep(1)
-        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
-        self.client.getDocument(
-            UID: uid,
-            identifier: "10"
-        ) { (result: Result<Movie, Swift.Error>) in
 
             switch result {
-            case .success(let returnedMovie):
-                print("HELLO")
-                print(returnedMovie)
-                XCTAssertEqual(movie, returnedMovie)
-                getExpectation.fulfill()
+
+            case .success(let update):
+
+                XCTAssertEqual(Update(updateId: 0), update)
+
+                Thread.sleep(forTimeInterval: 1.0)
+
+                self.client.getDocument(
+                    UID: self.uid,
+                    identifier: "\(identifier)"
+                ) { (result: Result<Movie, Swift.Error>) in
+
+                    switch result {
+                    case .success(let returnedMovie):
+                        XCTAssertEqual(movie, returnedMovie)
+                    case .failure(let error):
+                        print(error)
+                        XCTFail()
+                    }
+
+                    expectation.fulfill()
+                }
+
             case .failure(let error):
-                XCTFail(error.localizedDescription)
+                print(error)
+                XCTFail()
+                expectation.fulfill()
             }
+
         }
-        self.wait(for: [getExpectation], timeout: 3.0)
+
+        self.wait(for: [expectation], timeout: 5.0)
     }
 
-    func testDeleteOneDocument(){
+    func testDeleteOneDocument() {
+
         let documents: Data = try! JSONEncoder().encode(movies)
 
         let expectation = XCTestExpectation(description: "Delete one Movie")
         self.client.addDocuments(
-            UID: uid,
+            UID: self.uid,
             documents: documents,
             primaryKey: nil
         ) { result in
@@ -246,69 +292,158 @@ class DocumentsTests: XCTestCase {
             }
         }
         self.wait(for: [expectation], timeout: 1.0)
-        sleep(1)
+
         let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
-        self.client.deleteDocument(UID: uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
+        self.client.deleteDocument(UID: self.uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
             switch result {
             case .success(let update):
                 XCTAssertEqual(Update(updateId: 1), update)
                 deleteExpectation.fulfill()
             case .failure(let error):
-                XCTFail(error.localizedDescription)
+                print(error)
+                XCTFail()
             }
         }
         self.wait(for: [deleteExpectation], timeout: 3.0)
 
-        sleep(1)
         let getExpectation = XCTestExpectation(description: "Add or update Movies document")
         self.client.getDocument(
-            UID: uid,
+            UID: self.uid,
             identifier: "10"
         ) { (result: Result<Movie, Swift.Error>) in
             switch result {
             case .success:
                 XCTFail("Movie should not exist")
-            case .failure(let error):
-                // How can I get information from the error
-//                print(underlyingError.HttpStatus)
+            case .failure:
                 getExpectation.fulfill()
             }
         }
         self.wait(for: [getExpectation], timeout: 3.0)
 
-
     }
 
-    private func convertToDictionary(_ string: String) -> [String: Any] {
-        if let data: Data = string.data(using: .utf8) {
-            do {
-                return try JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
-            } catch {
-                fatalError(error.localizedDescription)
+    func testDeleteAllDocuments() {
+        let documents: Data = try! JSONEncoder().encode(movies)
+
+        let expectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.addDocuments(
+            UID: self.uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 0), update)
+                expectation.fulfill()
+            case .failure:
+                XCTFail("Failed to add or replace Movies document")
             }
         }
-        fatalError()
+        self.wait(for: [expectation], timeout: 1.0)
+
+        let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
+        self.client.deleteAllDocuments(UID: uid) { (result: Result<Update, Swift.Error>) in
+            switch result {
+            case .success(let update):
+                XCTAssertEqual(Update(updateId: 1), update)
+                deleteExpectation.fulfill()
+            case .failure(let error):
+                print(error)
+                XCTFail()
+            }
+        }
+        self.wait(for: [deleteExpectation], timeout: 3.0)
+
+        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+        self.client.getDocuments(
+            UID: self.uid,
+            limit: 20
+        ) { (result: Result<[Movie], Swift.Error>) in
+            switch result {
+            case .success(let results):
+                XCTAssertEqual([], results)
+                getExpectation.fulfill()
+            case .failure(let error):
+                print(error)
+                XCTFail()
+            }
+        }
+
+        self.wait(for: [getExpectation], timeout: 3.0)
     }
 
-    private func convertToArrayDictionary(_ string: String) -> [[String: Any]] {
-        if let data: Data = string.data(using: .utf8) {
-            do {
-                return try JSONSerialization.jsonObject(with: data, options: []) as! [[String: Any]]
-            } catch {
-                fatalError(error.localizedDescription)
+    func testDeleteBatchDocuments() {
+
+        let documents: Data = try! JSONEncoder().encode(movies)
+
+        let expectation = XCTestExpectation(description: "Delete batch movies")
+
+        self.client.addDocuments(
+            UID: self.uid,
+            documents: documents,
+            primaryKey: nil
+        ) { result in
+
+            switch result {
+
+            case .success(let update):
+
+                XCTAssertEqual(Update(updateId: 0), update)
+
+                Thread.sleep(forTimeInterval: 1.0)
+
+                let idsToDelete: [Int] = [2, 1, 4]
+
+                self.client.deleteBatchDocuments(UID: self.uid, documentsUID: idsToDelete) { (result: Result<Update, Swift.Error>) in
+                    switch result {
+
+                    case .success(let update):
+
+                        XCTAssertEqual(Update(updateId: 1), update)
+
+                        Thread.sleep(forTimeInterval: 1.0)
+
+                        self.client.getDocuments(
+                            UID: self.uid,
+                            limit: 20
+                        ) { (result: Result<[Movie], Swift.Error>) in
+                            switch result {
+                            case .success(let results):
+                                let filteredMovies: [Movie] = movies.filter { (movie: Movie) in !idsToDelete.contains(movie.id) }
+                                XCTAssertEqual(filteredMovies, results)
+                                expectation.fulfill()
+                            case .failure(let error):
+                                print(error)
+                                XCTFail()
+                            }
+                        }
+
+                    case .failure(let error):
+                        print(error)
+                        XCTFail()
+                        expectation.fulfill()
+                    }
+                }
+
+            case .failure:
+                XCTFail("Failed to delete batch movies")
+                expectation.fulfill()
             }
+
         }
-        fatalError()
+
+        self.wait(for: [expectation], timeout: 5.0)
     }
 
     static var allTests = [
         ("testAddAndGetDocuments", testAddAndGetDocuments),
+        ("testGetOneDocumentAndFail", testGetOneDocumentAndFail),
+        ("testAddAndGetOneDocumentWithIntIdentifierAndSucceed", testAddAndGetOneDocumentWithIntIdentifierAndSucceed),
         ("testAddAndGetOneDocuments", testAddAndGetOneDocuments),
         ("testUpdateAndGetDocuments", testUpdateAndGetDocuments),
-        ("testDeleteOneDocument", testDeleteOneDocument)
-//        ("testDeleteDocument", testDeleteDocument),
-//        ("testDeleteAllDocuments", testDeleteAllDocuments),
-//        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
+        ("testDeleteOneDocument", testDeleteOneDocument),
+        ("testDeleteAllDocuments", testDeleteAllDocuments),
+        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
     ]
 
 }


### PR DESCRIPTION
Addresses the following issues: #75 and #40 

In this PR I try to transform MeiliSearch answer in an `MSerror` type.

Tests are failing, I would like some advice to how to make them work (see comments inside code).



Also I would like to remove the whole `CreateError` class. Which I'm not sure is really useful as it removed the purposed of having an `msError` object from which I should be able to look through every data MeilISearch send me:

- msError.errorCode
- msError.errorLink
- msError.errorCode 
- msError.message
- msError.errorType

Output print: 
```
MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "Document with id 123456 not found", errorCode: "document_not_found", errorType: "invalid_request_error", errorLink: Optional("https://docs.meilisearch.com/errors#document_not_found"))), underlying: Error Domain=HttpStatus Code=404 "(null)")
```