### PR TITLE
Create error handler

### DIFF
--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -70,8 +70,9 @@ struct Indexes {
                 completion(.success(index))
 
             case .failure(let error):
+                print(error)
                 switch error {
-                case CreateError.indexAlreadyExists:
+                case CreateError.indexAlreadyExists: // "index already exists" should be used using error.errorCode
                     self.get(UID, completion)
                 default:
                     completion(.failure(error))
@@ -213,26 +214,14 @@ public enum CreateError: Swift.Error, Equatable {
     // MARK: Codable
 
     static func decode(_ error: MSError) -> Swift.Error {
-
         let underlyingError: NSError = error.underlying as NSError
-
-        if let data = error.data {
-
-            let msErrorResponse: MSErrorResponse?
-            do {
-                let decoder: JSONDecoder = JSONDecoder()
-                msErrorResponse = try decoder.decode(MSErrorResponse.self, from: data)
-            } catch {
-                msErrorResponse = nil
-            }
-
-            if underlyingError.code == 400 && msErrorResponse?.errorType == "invalid_request_error" && msErrorResponse?.errorCode == "index_already_exists" {
+        if let msErrorResponse: MSErrorResponse = error.data {
+            if underlyingError.code == 400 && msErrorResponse.errorType == "invalid_request_error" && msErrorResponse.errorCode == "index_already_exists" {
                 return CreateError.indexAlreadyExists
             }
             return error
 
         }
-
         return error
     }
 }

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -80,11 +80,16 @@ final class Request {
 
                 if 400 ... 599 ~= response.statusCode {
                     if data != nil {
-                        let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
-                        completion(.failure(
+                        //  do {
+                           let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                            completion(.failure(
                             MSError(
-                            data: meiliSearchApiError,
-                            underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                                data: meiliSearchApiError,
+                                underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil)
+                            )))
+                        // } catch {
+                        //  Create a standard body error
+                        // }
                     }
                     else {
                         completion(.failure(

--- a/Sources/MeiliSearch/Request.swift
+++ b/Sources/MeiliSearch/Request.swift
@@ -21,8 +21,10 @@ public protocol URLSessionDataTaskProtocol {
     func resume()
 }
 
+// struct meiliSearchApiError: Codable
+
 struct MSError: Swift.Error {
-    let data: Data?
+    let data: MSErrorResponse?
     let underlying: Swift.Error
 }
 
@@ -77,10 +79,19 @@ final class Request {
                 }
 
                 if 400 ... 599 ~= response.statusCode {
-                    completion(.failure(
-                      MSError(
-                        data: data,
-                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    if data != nil {
+                        let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                        completion(.failure(
+                            MSError(
+                            data: meiliSearchApiError,
+                            underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    }
+                    else {
+                        completion(.failure(
+                        MSError(
+                            data: nil,
+                            underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                    }
                     return
                 }
 
@@ -111,7 +122,7 @@ final class Request {
         let task: URLSessionDataTaskProtocol = session.execute(with: request) { (data, response, error) in
 
             if let error: Swift.Error = error {
-                let msError = MSError(data: data, underlying: error)
+                let msError = MSError(data: nil, underlying: error)
                 completion(.failure(msError))
                 return
             }
@@ -121,10 +132,20 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                print(data)
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -166,10 +187,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 
@@ -205,10 +235,19 @@ final class Request {
             }
 
             if 400 ... 599 ~= response.statusCode {
-                completion(.failure(
-                  MSError(
-                    data: data,
-                    underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                if data != nil {
+                    let meiliSearchApiError = try! JSONDecoder().decode(MSErrorResponse.self, from: data!)
+                    completion(.failure(
+                        MSError(
+                        data: meiliSearchApiError,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
+                else {
+                    completion(.failure(
+                    MSError(
+                        data: nil,
+                        underlying: NSError(domain: "HttpStatus", code: response.statusCode, userInfo: nil))))
+                }
                 return
             }
 

--- a/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
@@ -80,7 +80,7 @@ class ErrorsTests: XCTestCase {
                 /*
                     MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "Document with id 123456 not found", errorCode: "document_not_found", errorType: "invalid_request_error", errorLink: Optional("https://docs.meilisearch.com/errors#document_not_found"))), underlying: Error Domain=HttpStatus Code=404 "(null)")
                 */
-                XCTAssertEqual("document_not_found", error.errorCode) // How do I say that error is a MSError ?
+                // XCTAssertEqual("document_not_found", error.errorCode) // How do I say that error is a MSError ?
                 getExpectation.fulfill()
             }
         }

--- a/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/ErrorsTests.swift
@@ -1,0 +1,114 @@
+@testable import MeiliSearch
+import XCTest
+import Foundation
+
+private struct Movie: Codable, Equatable {
+
+    let id: Int
+    let title: String
+    let comment: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case comment
+    }
+
+    init(id: Int, title: String, comment: String? = nil) {
+        self.id = id
+        self.title = title
+        self.comment = comment
+    }
+
+}
+
+private let movies: [Movie] = [
+    Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
+    Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
+    Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
+    Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
+    Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
+    Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
+    Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
+    Movie(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo")
+]
+
+class ErrorsTests: XCTestCase {
+
+    private var client: MeiliSearch!
+    private let uid: String = "books_test"
+
+    override func setUp() {
+        super.setUp()
+
+        if client == nil {
+            client = try! MeiliSearch(
+              Config.default(apiKey: "masterKey"))
+        }
+
+        pool(client)
+
+        let expectation = XCTestExpectation(description: "Create index if it does not exist")
+
+        self.client.deleteIndex(UID: uid) { _ in
+            self.client.getOrCreateIndex(UID: self.uid) { result in
+                switch result {
+                case .success:
+                    break
+                case .failure(let error):
+                    print(error)
+                }
+                expectation.fulfill()
+            }
+        }
+
+        self.wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testGetDocumentThatDoesNotExistAndFail() {
+
+        let getExpectation = XCTestExpectation(description: "Get one document and fail")
+        self.client.getDocument(
+            UID: self.uid,
+            identifier: "123456"
+        ) { (result: Result<Movie, Swift.Error>) in
+            switch result {
+            case .success:
+                XCTFail("Document has been found while it should not have")
+            case .failure(let error):
+                print(error) // Outputs the following
+                /*
+                    MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "Document with id 123456 not found", errorCode: "document_not_found", errorType: "invalid_request_error", errorLink: Optional("https://docs.meilisearch.com/errors#document_not_found"))), underlying: Error Domain=HttpStatus Code=404 "(null)")
+                */
+                XCTAssertEqual("document_not_found", error.errorCode) // How do I say that error is a MSError ?
+                getExpectation.fulfill()
+            }
+        }
+        self.wait(for: [getExpectation], timeout: 3.0)
+    }
+
+    func testCreateSameIndexTwiceAndFail() {
+        // "index already exists" shoudl be used using error.errorCode
+        let createExpectation = XCTestExpectation(description: "Create same index twice")
+
+        self.client.createIndex(UID: self.uid) { result in
+            switch result {
+            case .success:
+                XCTFail("Create Index should not have worked")
+            case .failure(let error):
+                print(error)
+                // XCTAssertEqual("index_already_exists", error.)
+                createExpectation.fulfill()
+            }
+        }
+
+        self.wait(for: [createExpectation], timeout: 1.0)
+    }
+
+
+
+    static var allTests = [
+        ("testCreateSameIndexTwiceAndFail", testCreateSameIndexTwiceAndFail),
+    ]
+
+}


### PR DESCRIPTION
Addresses the following issues: #75 and #40 

## Problem need addressing 

Cannot make error with standard Error body.

----


In this PR I try to transform MeiliSearch answer in an `MSerror` type.

Tests are failing, I would like some advice to how to make them work (see comments inside code).



Also I would like to remove the whole `CreateError` class. Which I'm not sure is really useful as it removed the purposed of having an `msError` object from which I should be able to look through every data MeilISearch send me:

- msError.errorCode
- msError.errorLink
- msError.errorCode 
- msError.message
- msError.errorType

Output print: 
```
MSError(data: Optional(MeiliSearch.MSErrorResponse(message: "Document with id 123456 not found", errorCode: "document_not_found", errorType: "invalid_request_error", errorLink: Optional("https://docs.meilisearch.com/errors#document_not_found"))), underlying: Error Domain=HttpStatus Code=404 "(null)")
```

##  TODO 
- [ ] refactor request by putting the error handler in a dedicated file and not 4 copies of it in requests
- [ ] Remove `createError`
- [ ] Fix error that does not accept standard body error