### PR TITLE
Fix docs CI

### DIFF
--- a/.github/workflows/swift-docs.yml
+++ b/.github/workflows/swift-docs.yml
@@ -1,11 +1,12 @@
-name: Swift
+name: Swift Docs
 
 on:
   push:
     branches: [master]
 
 jobs:
-  build:
+  docs:
+
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.5.app/Contents/Developer
@@ -14,12 +15,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           swift-version: "5.2.0"
-
-      - name: Run SwiftLint
-        run: sh ./Scripts/swiftlint.sh
-
-      - name: Run tests
-        run: swift test -v
 
       - name: Publish Jazzy Docs
         uses: Steven0351/publish-jazzy-docs@v1.1.1


### PR DESCRIPTION
I don't know why I did not notice it before, but the tests (in the CI related to the docs) couldn't pass without running a MeiliSearch instance and was failing.

https://github.com/meilisearch/meilisearch-swift/actions/runs/315076817

No need to run the tests since they already run:
- on each PR
- once merged to master

PS: I renamed the test for a better understanding