### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -106,7 +106,7 @@ delete_one_document_1: |-
   }
 delete_documents_1: |-
   client.deleteBatchDocuments(
-    UID: "movies", 
+    UID: "movies",
     documentsUID: [23488, 153738, 437035, 363869]) { (result: Result<Update, Swift.Error>) in
         switch result {
         case .success(let update):
@@ -372,7 +372,7 @@ get_displayed_attributes_1: |-
       }
   }
 update_displayed_attributes_1: |-
-  let displayedAttributes: [String] = ["title", "description", "release_date", "rank", "poster"]        
+  let displayedAttributes: [String] = ["title", "description", "release_date", "rank", "poster"]
   client.updateDisplayedAttributes(UID: "movies", displayedAttributes) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
@@ -436,15 +436,6 @@ get_health_1: |-
           print(error)
       }
   }
-update_health_1: |-
-  client.updateHealth(health: "movies") { (result: Result<(), Swift.Error>) in
-      switch result {
-      case .success:
-          print("Health updated!")
-      case .failure(let error):
-          print(error)
-      }
-  }
 get_version_1: |-
   client.version { (result: Result<Version, Swift.Error>) in
       switch result {
@@ -483,14 +474,14 @@ distinct_attribute_guide_1: |-
   }
 field_properties_guide_searchable_1: |-
   let searchableAttributes: [String] = [
-      "uid", 
-      "movie_id", 
-      "title", 
-      "description", 
-      "poster", 
-      "release_date", 
+      "uid",
+      "movie_id",
+      "title",
+      "description",
+      "poster",
+      "release_date",
       "rank"
-  ]     
+  ]
   client.updateSearchableAttributes(UID: "movies", searchableAttributes) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
@@ -501,12 +492,12 @@ field_properties_guide_searchable_1: |-
   }
 field_properties_guide_displayed_1: |-
   let displayedAttributes: [String] = [
-      "title", 
-      "description", 
-      "poster", 
-      "release_date", 
+      "title",
+      "description",
+      "poster",
+      "release_date",
       "rank"
-  ]        
+  ]
   client.updateDisplayedAttributes(UID: "movies", displayedAttributes) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
@@ -673,8 +664,8 @@ search_parameter_guide_matches_1: |-
   }
 settings_guide_stop_words_1: |-
   let stopWords: [String] = [
-      "the", 
-      "a", 
+      "the",
+      "a",
       "an"
   ]
   client.updateStopWords(UID: "movies", stopWords) { (result: Result<Update, Swift.Error>) in
@@ -715,14 +706,14 @@ settings_guide_distinct_1: |-
   }
 settings_guide_searchable_1: |-
   let searchableAttributes: [String] = [
-      "uid", 
-      "movie_id", 
-      "title", 
-      "description", 
-      "poster", 
-      "release_date", 
+      "uid",
+      "movie_id",
+      "title",
+      "description",
+      "poster",
+      "release_date",
       "rank"
-  ]     
+  ]
   client.updateSearchableAttributes(UID: "movies", searchableAttributes) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
@@ -733,12 +724,12 @@ settings_guide_searchable_1: |-
   }
 settings_guide_displayed_1: |-
   let displayedAttributes: [String] = [
-      "title", 
-      "description", 
-      "poster", 
-      "release_date", 
+      "title",
+      "description",
+      "poster",
+      "release_date",
       "rank"
-  ]        
+  ]
   client.updateDisplayedAttributes(UID: "movies", displayedAttributes) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
@@ -785,8 +776,8 @@ documents_guide_add_movie_1: |-
   }
 search_guide_1: |-
   let parameters = SearchParameters(
-      query: "shifu", 
-      limit: 5, 
+      query: "shifu",
+      limit: 5,
       offset: 10)
   client.search(UID: "movies", parameters) { (result: Result<SearchResult<Movie>, Swift.Error>) in
       switch result {
@@ -798,7 +789,7 @@ search_guide_1: |-
   }
 search_guide_2: |-
   let parameters = SearchParameters(
-      query: "Avengers", 
+      query: "Avengers",
       filters: "release_date > 795484800")
   client.search(UID: "movies", parameters) { (result: Result<SearchResult<Movie>, Swift.Error>) in
       switch result {
@@ -809,7 +800,7 @@ search_guide_2: |-
       }
   }
 getting_started_create_index_md: |-
-  Add this in your `Package.swift`:  
+  Add this in your `Package.swift`:
   ```
     dependencies: [
       .package(url: "https://github.com/meilisearch/meilisearch-swift.git")
@@ -828,7 +819,7 @@ getting_started_create_index_md: |-
     }
   ```
 getting_started_add_documents_md: |-
-  Add this in your `Package.swift`:  
+  Add this in your `Package.swift`:
   ```
     dependencies: [
       .package(url: "https://github.com/meilisearch/meilisearch-swift.git")
@@ -848,7 +839,7 @@ getting_started_add_documents_md: |-
     }
   ```
 getting_started_search_md: |-
-  Add this in your `Package.swift`:  
+  Add this in your `Package.swift`:
   ```
     dependencies: [
       .package(url: "https://github.com/meilisearch/meilisearch-swift.git")

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ private struct Movie: Codable, Equatable {
 
 ## Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## Demo
 

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -793,7 +793,7 @@ public struct MeiliSearch {
     // MARK: System
 
     /**
-     Update health of MeiliSearch server.
+     Get health of MeiliSearch server.
 
      - parameter completion: The completion closure used to notify when the server
      completes the query request, it returns a `Result` object that contains `()` value.
@@ -801,20 +801,6 @@ public struct MeiliSearch {
      */
     public func health(_ completion: @escaping (Result<(), Swift.Error>) -> Void) {
         self.system.health(completion)
-    }
-
-    /**
-     Get health of MeiliSearch server.
-
-     - parameter health:     Set the MeiliSearch server health status.
-     - parameter completion: The completion closure used to notify when the server
-     completes the query request, it returns a `Result` object that contains `()` value.
-     If the request was sucessful or `Error` if a failure occured.
-     */
-    public func updateHealth(
-        health: Bool,
-        _ completion: @escaping (Result<(), Swift.Error>) -> Void) {
-        self.system.updateHealth(health, completion)
     }
 
     /**

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -846,8 +846,8 @@ public struct MeiliSearch {
      Get the status of a dump creation process using the uid returned after calling the dump creation route.
      The returned status could be:
 
-     `Dump.Status.processing`: Dump creation is in progress.
-     `Dump.Status.dumpProcessFailed`: An error occurred during the dump process, and the task was aborted.
+     `Dump.Status.inProgress`: Dump creation is in progress.
+     `Dump.Status.failed`: An error occurred during the dump process, and the task was aborted.
      `Dump.Status.done`: Dump creation is finished and was successful.
 
      - parameter completion: The completion closure used to notify when the server

--- a/Sources/MeiliSearch/Model/Dump.swift
+++ b/Sources/MeiliSearch/Model/Dump.swift
@@ -20,8 +20,8 @@ public struct Dump: Codable, Equatable {
 
     public enum Status: Codable, Equatable {
 
-        case processing
-        case dumpProcessFailed
+        case inProgress
+        case failed
         case done
 
         public enum CodingError: Error {
@@ -32,10 +32,10 @@ public struct Dump: Codable, Equatable {
             let container = try decoder.singleValueContainer()
             let rawStatus = try container.decode(String.self)
             switch rawStatus {
-            case "processing":
-                self = .processing
+            case "in_progress":
+                self = .inProgress
             case "dump_process_failed":
-                self = .dumpProcessFailed
+                self = .failed
             case "done":
                 self = .done
             default:

--- a/Sources/MeiliSearch/System.swift
+++ b/Sources/MeiliSearch/System.swift
@@ -26,27 +26,6 @@ struct System {
         }
     }
 
-    func updateHealth(_ health: Bool, _ completion: @escaping (Result<(), Swift.Error>) -> Void) {
-        let data: Data
-
-        do {
-            data = try JSONEncoder().encode(CreateHealthPayload(health: health))
-        } catch {
-            completion(.failure(MeiliSearch.Error.invalidJSON))
-            return
-        }
-
-        request.put(api: "/health", data) { result in
-            switch result {
-            case .success:
-                completion(.success(()))
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
-        }
-    }
-
     func version(_ completion: @escaping (Result<Version, Swift.Error>) -> Void) {
         request.get(api: "/version") { result in
             switch result {

--- a/Tests/MeiliSearchUnitTests/DumpsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DumpsTests.swift
@@ -18,7 +18,7 @@ class DumpsTests: XCTestCase {
         let json = """
         {
           "uid": "20200929-114144097",
-          "status": "processing"
+          "status": "in_progress"
         }
         """
 
@@ -53,7 +53,7 @@ class DumpsTests: XCTestCase {
         let json = """
         {
           "uid": "20200929-114144097",
-          "status": "processing"
+          "status": "in_progress"
         }
         """
 

--- a/Tests/MeiliSearchUnitTests/SystemTests.swift
+++ b/Tests/MeiliSearchUnitTests/SystemTests.swift
@@ -35,29 +35,6 @@ class SystemTests: XCTestCase {
 
     }
 
-    func testUpdateHealth() {
-
-        //Prepare the mock server
-
-        session.pushEmpty(code: 204)
-
-        // Start the test with the mocked server
-
-        let expectation = XCTestExpectation(description: "Check server health")
-
-        self.client.updateHealth(health: true) { result in
-            switch result {
-            case .success:
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to check server health")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
     func testVersion() {
 
         //Prepare the mock server
@@ -98,7 +75,6 @@ class SystemTests: XCTestCase {
 
     static var allTests = [
         ("testHealth", testHealth),
-        ("testUpdateHealth", testUpdateHealth),
         ("testVersion", testVersion)
     ]
 }


### PR DESCRIPTION
Related to this issue: https://github.com/meilisearch/integration-guides/issues/52

- [x] Update README
- [x] Update dumps status #89 
- [x] Remove the `updateHealth` method #90

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.