### PR TITLE
Changes about the MeiliSearch's next release (v0.17.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ private struct Movie: Codable, Equatable {
 
 ## Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
+This package only guarantees the compatibility with the [version v0.17.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.17.0).
 
 ## Demo
 


### PR DESCRIPTION
The next version of MeiliSearch (v0.17.0) will not bring any change to this package.
That's why only the section about the compatibility in the README.md is updated.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.17.0) is out.