### PR TITLE
Make SearchParameters initializer public

### DIFF
--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -44,7 +44,7 @@ public struct SearchParameters: Codable, Equatable {
 
     // MARK: Initializers
 
-    init(
+    public init(
         query: String?,
         offset: Int? = nil,
         limit: Int? = nil,


### PR DESCRIPTION
Addresses Issue: #94 

# Summary

This fixes an issue where the `SearchParameters` could be modified from outside the library.
By making the initializer public, the `SearchParameters` can be configured individually.

# Discussion

I am not sure whether tests are necessary in this case, as this is a very simple fix changing only one line.