### PR TITLE
Add support to Cocoapods

### DIFF
--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
 
   s.homepage         = 'https://github.com/meilisearch/meilisearch-swift'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Meilisearch' => 'bonjour@meilisearch.com' }
+  s.author           = { 'MeiliSearch' => 'bonjour@meilisearch.com' }
   s.source           = { :git => 'https://github.com/meilisearch/meilisearch-swift.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/meilisearch'
 

--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |s|
   s.name             = 'MeiliSearch'
   s.version          = '0.7.1'
-  s.summary          = 'Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine Client written in Swift'
+  s.summary          = 'The MeiliSearch API client written in Swift'
 
 # This description is used to generate tags and improve search results.
 #   * Think: What does it do? Why did you write it? What is the focus?

--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -1,0 +1,44 @@
+#
+# Be sure to run `pod lib lint MeiliSearch.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'MeiliSearch'
+  s.version          = '0.7.1'
+  s.summary          = 'Lightning Fast, Ultra Relevant, and Typo-Tolerant Search Engine Client written in Swift'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+  MeiliSearch-Swift is a client for MeiliSearch written in Swift.
+
+  ## Features:
+
+    * Complete full API wrapper
+    * Easy to install, deploy, and maintain
+    * Highly customizable
+    * No external dependencies
+    * Thread safe
+    * Uses Codable
+                       DESC
+
+  s.homepage         = 'https://github.com/meilisearch/meilisearch-swift'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Meilisearch' => 'bonjour@meilisearch.com' }
+  s.source           = { :git => 'https://github.com/meilisearch/meilisearch-swift.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/meilisearch'
+
+  s.source_files = 'Sources/**/*'
+  s.swift_versions = ['5.2']
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.10'
+
+end

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ For more information about features go to [our Swift documentation](https://meil
 
 ## Get started
 
+### Cocoapods
+
+[CocoaPods](https://cocoapods.org/) is a dependency manager for Cocoa projects.
+
+**MeiliSearch-Swift** is available through [CocoaPods](https://cocoapods.org). To install
+it, simply add the following line to your Podfile:
+
+```ruby
+pod 'MeiliSearch'
+```
+
+Then run `pod install` to download the latest dependency and prepare the `xcworkspace`.
+
 ### Swift Package Manager
 
 The [Swift Package Manager](https://swift.org/package-manager/) is a tool for automating the distribution of Swift code and is integrated into the `swift` compiler.


### PR DESCRIPTION
This PR does the same as the first PR open for this feature but it's simply because it excludes all non-necessary files from `Cocoapods` initial setup.

After the deployment of the version 0.7.1, the artifact will be pushed to the `Cocoapods` repository. The PR is validated by the command `pod spec lint`. Waiting for the deployment of 0.7.1 to run `pod spec lint` and `pod trunk push Meilisearch.podspec` to deploy the library.

Answering some questions from @curquiza:

1. Could you explain how to update the package in `cocoapods` in a step-by-step manner? Can it be added to the release process `github action`? 

A: Once the repository is published on `Cocoapods`, it fetches the latest version from the tag.

2. Who is the owner of this package in `Cocoapods`?

A: The repository owner.

3. About your comment `If possible we will keep cutting these files down`. I would prefer us to know what we add to the package. I saw this PR improve a lot. Do you know what the remaining files are used for? Could you explain a bit?

A: Question sorted with this PR.

