### PR TITLE
Add SwiftLint for demos and tests

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,8 +3,13 @@ disabled_rules:
   - type_body_length
   - file_length
   - nesting # should be re-enabled
+  - xctfail_message
 
-opt_in_rules: # some rules are only opt-in
+analyzer_rules:
+  - unused_declaration
+  - unused_import
+
+opt_in_rules:
   - explicit_type_interface
   - force_unwrapping
   - implicit_return
@@ -19,15 +24,11 @@ opt_in_rules: # some rules are only opt-in
 excluded:
   - Carthage
   - Pods
-  - Demos/VaporDemo
-  - Demos/PerfectDemo
-  - Tests
   - .build
 
 force_cast: warning
 force_try: warning
 
-# - Force explicity type for every variable on the project, this is needed to let the Swift compiler more lightweight
 explicit_type_interface:
   severity: warning
 

--- a/Demos/PerfectDemo/Sources/PerfectTemplate/main.swift
+++ b/Demos/PerfectDemo/Sources/PerfectTemplate/main.swift
@@ -22,25 +22,27 @@ import PerfectHTTPServer
 import MeiliSearch
 import Foundation
 
+// swiftlint:disable force_try
 private let client = try! MeiliSearch(Config.default(apiKey: "masterKey"))
+// swiftlint:disable force_try
 
 private struct Movie: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let comment: String?
+  let id: Int
+  let title: String
+  let comment: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case comment
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+  }
 
-    init(id: Int, title: String, comment: String? = nil) {
-        self.id = id
-        self.title = title
-        self.comment = comment
-    }
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+  }
 
 }
 
@@ -146,8 +148,9 @@ func search(request: HTTPRequest, response: HTTPResponse) {
 var routes = Routes()
 routes.add(method: .get, uri: "/index", handler: index)
 routes.add(method: .get, uri: "/search", handler: search)
-try HTTPServer.launch(name: "localhost",
-					  port: 8181,
-					  routes: routes,
-					  responseFilters: [
-						(PerfectHTTPServer.HTTPFilter.contentCompression(data: [:]), HTTPFilterPriority.high)])
+try HTTPServer.launch(
+  name: "localhost",
+  port: 8181,
+  routes: routes,
+  responseFilters: [
+  (PerfectHTTPServer.HTTPFilter.contentCompression(data: [:]), HTTPFilterPriority.high)])

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -8,6 +8,7 @@ import Foundation
  or dispatch queues.
  */
 public struct MeiliSearch {
+
   // MARK: Properties
 
   /**

--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -2,519 +2,523 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 private struct Movie: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let comment: String?
+  let id: Int
+  let title: String
+  let comment: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case comment
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+  }
 
-    init(id: Int, title: String, comment: String? = nil) {
-        self.id = id
-        self.title = title
-        self.comment = comment
-    }
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+  }
 
 }
 
 private let movies: [Movie] = [
-    Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
-    Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
-    Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
-    Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
-    Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
-    Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
-    Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
-    Movie(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo")
+  Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
+  Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
+  Movie(id: 2, title: "Le Rouge et le Noir", comment: "Another french book"),
+  Movie(id: 1, title: "Alice In Wonderland", comment: "A weird book"),
+  Movie(id: 1344, title: "The Hobbit", comment: "An awesome book"),
+  Movie(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book"),
+  Movie(id: 42, title: "The Hitchhiker's Guide to the Galaxy"),
+  Movie(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo")
 ]
 
 class DocumentsTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+    super.setUp()
 
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-
-        pool(client)
-
-        let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.deleteIndex(UID: uid) { _ in
-            self.client.getOrCreateIndex(UID: self.uid) { result in
-                switch result {
-                case .success:
-                    break
-                case .failure(let error):
-                    print(error)
-                }
-                expectation.fulfill()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
 
-    func testAddAndGetDocuments() {
+    pool(client)
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+    let expectation = XCTestExpectation(description: "Create index if it does not exist")
 
-        self.client.addDocuments(
+    self.client.deleteIndex(UID: uid) { _ in
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+        switch result {
+        case .success:
+          break
+        case .failure(let error):
+          print(error)
+        }
+        expectation.fulfill()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 10.0)
+  }
+
+  func testAddAndGetDocuments() {
+
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
+
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: movies,
+      primaryKey: nil
+    ) { result in
+
+      switch result {
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDocuments(
             UID: self.uid,
-            documents: movies,
-            primaryKey: nil
-        ) { result in
+            limit: 20
+          ) { (result: Result<[Movie], Swift.Error>) in
 
             switch result {
-            case .success(let update):
+            case .success(let returnedMovies):
 
-                XCTAssertEqual(Update(updateId: 0), update)
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getDocuments(
-                        UID: self.uid,
-                        limit: 20
-                    ) { (result: Result<[Movie], Swift.Error>) in
-
-                        switch result {
-                        case .success(let returnedMovies):
-
-                            movies.forEach { (movie: Movie) in
-                                XCTAssertTrue(returnedMovies.contains(movie))
-                            }
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                        expectation.fulfill()
-                    }
-
-                }
+              movies.forEach { (movie: Movie) in
+                XCTAssertTrue(returnedMovies.contains(movie))
+              }
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+            expectation.fulfill()
+          }
+
         }
-        self.wait(for: [expectation], timeout: 5.0)
 
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
+    self.wait(for: [expectation], timeout: 5.0)
 
-    func testAddDataAndGetDocuments() {
-        let documents: Data = try! JSONEncoder().encode(movies)
+  }
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+  func testAddDataAndGetDocuments() {
+    let documents: Data = try! JSONEncoder().encode(movies)
 
-        self.client.addDocuments(
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
+
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+
+      switch result {
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDocuments(
             UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
+            limit: 20
+          ) { (result: Result<[Movie], Swift.Error>) in
 
             switch result {
-            case .success(let update):
+            case .success(let returnedMovies):
 
-                XCTAssertEqual(Update(updateId: 0), update)
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getDocuments(
-                        UID: self.uid,
-                        limit: 20
-                    ) { (result: Result<[Movie], Swift.Error>) in
-
-                        switch result {
-                        case .success(let returnedMovies):
-
-                            movies.forEach { (movie: Movie) in
-                                XCTAssertTrue(returnedMovies.contains(movie))
-                            }
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                        expectation.fulfill()
-                    }
-
-                }
+              movies.forEach { (movie: Movie) in
+                XCTAssertTrue(returnedMovies.contains(movie))
+              }
 
             case .failure(let error):
-                    print(error)
-                    XCTFail()
+              print(error)
+              XCTFail()
             }
+
+            expectation.fulfill()
+          }
+
         }
-        self.wait(for: [expectation], timeout: 5.0)
 
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
+    self.wait(for: [expectation], timeout: 5.0)
 
-    func testGetOneDocumentAndFail() {
+  }
 
-        let getExpectation = XCTestExpectation(description: "Get one document and fail")
-        self.client.getDocument(
-            UID: self.uid,
-            identifier: "123456"
-        ) { (result: Result<Movie, Swift.Error>) in
-            switch result {
-            case .success:
-                XCTFail("Document has been found while it should not have")
-            case .failure:
-                getExpectation.fulfill()
-            }
-        }
-        self.wait(for: [getExpectation], timeout: 3.0)
+  func testGetOneDocumentAndFail() {
+
+    let getExpectation = XCTestExpectation(description: "Get one document and fail")
+    self.client.getDocument(
+      UID: self.uid,
+      identifier: "123456"
+    ) { (result: Result<Movie, Swift.Error>) in
+      switch result {
+      case .success:
+        XCTFail("Document has been found while it should not have")
+      case .failure:
+        getExpectation.fulfill()
+      }
     }
+    self.wait(for: [getExpectation], timeout: 3.0)
+  }
 
-    func testAddAndGetOneDocumentWithIntIdentifierAndSucceed() {
+  func testAddAndGetOneDocumentWithIntIdentifierAndSucceed() {
 
-        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
-        let documents: Data = try! JSONEncoder().encode([movie])
+    let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+    let documents: Data = try! JSONEncoder().encode([movie])
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
-        self.client.addDocuments(
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+
+      switch result {
+
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDocument(
             UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
+            identifier: 10
+          ) { (result: Result<Movie, Swift.Error>) in
 
             switch result {
-
-            case .success(let update):
-
-                XCTAssertEqual(Update(updateId: 0), update)
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getDocument(
-                    UID: self.uid,
-                    identifier: 10
-                    ) { (result: Result<Movie, Swift.Error>) in
-
-                        switch result {
-                        case .success(let returnedMovie):
-                            XCTAssertEqual(movie, returnedMovie)
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-                        expectation.fulfill()
-
-                    }
-
-                }
-
+            case .success(let returnedMovie):
+              XCTAssertEqual(movie, returnedMovie)
             case .failure(let error):
-                print(error)
-                XCTFail()
-                expectation.fulfill()
+              print(error)
+              XCTFail()
             }
+            expectation.fulfill()
+
+          }
 
         }
 
-         self.wait(for: [expectation], timeout: 5.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+        expectation.fulfill()
+      }
+
     }
 
-    func testAddAndGetOneDocuments() {
+    self.wait(for: [expectation], timeout: 5.0)
+  }
 
-        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
-        let documents: Data = try! JSONEncoder().encode([movie])
+  func testAddAndGetOneDocuments() {
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+    let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+    let documents: Data = try! JSONEncoder().encode([movie])
 
-        self.client.addDocuments(
-            UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
-            switch result {
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
 
-            case .success(let update):
+      switch result {
 
-                XCTAssertEqual(Update(updateId: 0), update)
+      case .success(let update):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+        XCTAssertEqual(Update(updateId: 0), update)
 
-                    self.client.getDocument(
-                        UID: self.uid,
-                        identifier: "10"
-                    ) { (result: Result<Movie, Swift.Error>) in
+        waitForPendingUpdate(self.client, self.uid, update) {
 
-                        switch result {
-                        case .success(let returnedMovie):
-                            XCTAssertEqual(movie, returnedMovie)
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-                        expectation.fulfill()
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-                expectation.fulfill()
-            }
-
-        }
-
-         self.wait(for: [expectation], timeout: 5.0)
-    }
-
-    func testUpdateAndGetDocuments() {
-
-        let identifier: Int = 1844
-
-        let movie: Movie = movies.first(where: { (movie: Movie) in movie.id == identifier })!
-        let documents: Data = try! JSONEncoder().encode([movie])
-
-        let expectation = XCTestExpectation(description: "Add or update Movies document")
-
-        self.client.updateDocuments(
-            UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
-
-            switch result {
-
-            case .success(let update):
-
-                XCTAssertEqual(Update(updateId: 0), update)
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getDocument(
-                        UID: self.uid,
-                        identifier: "\(identifier)"
-                    ) { (result: Result<Movie, Swift.Error>) in
-
-                        switch result {
-                        case .success(let returnedMovie):
-                            XCTAssertEqual(movie, returnedMovie)
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                        expectation.fulfill()
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-                expectation.fulfill()
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 5.0)
-    }
-
-    func testDeleteOneDocument() {
-
-        let documents: Data = try! JSONEncoder().encode(movies)
-
-        let expectation = XCTestExpectation(description: "Delete one Movie")
-        self.client.addDocuments(
-            UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 0), update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or replace Movies document")
-            }
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-
-        let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
-        self.client.deleteDocument(UID: self.uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(Update(updateId: 1), update)
-                deleteExpectation.fulfill()
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-        self.wait(for: [deleteExpectation], timeout: 3.0)
-
-        let getExpectation = XCTestExpectation(description: "Add or update Movies document")
-        self.client.getDocument(
+          self.client.getDocument(
             UID: self.uid,
             identifier: "10"
-        ) { (result: Result<Movie, Swift.Error>) in
+          ) { (result: Result<Movie, Swift.Error>) in
+
             switch result {
-            case .success:
-                XCTFail("Movie should not exist")
-            case .failure:
-                getExpectation.fulfill()
+            case .success(let returnedMovie):
+              XCTAssertEqual(movie, returnedMovie)
+            case .failure(let error):
+              print(error)
+              XCTFail()
             }
+            expectation.fulfill()
+
+          }
+
         }
-        self.wait(for: [getExpectation], timeout: 3.0)
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+        expectation.fulfill()
+      }
 
     }
 
-    func testDeleteAllDocuments() {
-        let documents: Data = try! JSONEncoder().encode(movies)
+    self.wait(for: [expectation], timeout: 5.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Delete one Movie")
-        self.client.addDocuments(
+  func testUpdateAndGetDocuments() {
+
+    let identifier: Int = 1844
+
+    let movie: Movie = movies.first(where: { (movie: Movie) in movie.id == identifier })!
+    let documents: Data = try! JSONEncoder().encode([movie])
+
+    let expectation = XCTestExpectation(description: "Add or update Movies document")
+
+    self.client.updateDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+
+      switch result {
+
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDocument(
             UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
+            identifier: "\(identifier)"
+          ) { (result: Result<Movie, Swift.Error>) in
+
+            switch result {
+            case .success(let returnedMovie):
+              XCTAssertEqual(movie, returnedMovie)
+            case .failure(let error):
+              print(error)
+              XCTFail()
+            }
+
+            expectation.fulfill()
+          }
+
+        }
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+        expectation.fulfill()
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 5.0)
+  }
+
+  func testDeleteOneDocument() {
+
+    let documents: Data = try! JSONEncoder().encode(movies)
+
+    let expectation = XCTestExpectation(description: "Delete one Movie")
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(Update(updateId: 0), update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to add or replace Movies document")
+      }
+    }
+    self.wait(for: [expectation], timeout: 1.0)
+
+    let deleteExpectation = XCTestExpectation(description: "Delete one Movie")
+    self.client.deleteDocument(UID: self.uid, identifier: "42") { (result: Result<Update, Swift.Error>) in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(Update(updateId: 1), update)
+        deleteExpectation.fulfill()
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+    self.wait(for: [deleteExpectation], timeout: 3.0)
+
+    let getExpectation = XCTestExpectation(description: "Add or update Movies document")
+    self.client.getDocument(
+      UID: self.uid,
+      identifier: "10"
+    ) { (result: Result<Movie, Swift.Error>) in
+      switch result {
+      case .success:
+        XCTFail("Movie should not exist")
+      case .failure:
+        getExpectation.fulfill()
+      }
+    }
+    self.wait(for: [getExpectation], timeout: 3.0)
+
+  }
+
+  func testDeleteAllDocuments() {
+    let documents: Data = try! JSONEncoder().encode(movies)
+
+    let expectation = XCTestExpectation(description: "Delete one Movie")
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+      switch result {
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.deleteAllDocuments(UID: self.uid) { (result: Result<Update, Swift.Error>) in
             switch result {
             case .success(let update):
 
-                XCTAssertEqual(Update(updateId: 0), update)
+              XCTAssertEqual(Update(updateId: 1), update)
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              waitForPendingUpdate(self.client, self.uid, update) {
 
-                    self.client.deleteAllDocuments(UID: self.uid) { (result: Result<Update, Swift.Error>) in
-                        switch result {
-                        case .success(let update):
-
-                            XCTAssertEqual(Update(updateId: 1), update)
-
-                            waitForPendingUpdate(self.client, self.uid, update) {
-
-                                self.client.getDocuments(
-                                    UID: self.uid,
-                                    limit: 20
-                                ) { (result: Result<[Movie], Swift.Error>) in
-                                    switch result {
-                                    case .success(let results):
-                                        XCTAssertEqual([], results)
-                                        expectation.fulfill()
-                                    case .failure(let error):
-                                        print(error)
-                                        XCTFail()
-                                        expectation.fulfill()
-                                    }
-                                }
-
-                            }
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                            expectation.fulfill()
-                        }
-                    }
-
+                self.client.getDocuments(
+                  UID: self.uid,
+                  limit: 20
+                ) { (result: Result<[Movie], Swift.Error>) in
+                  switch result {
+                  case .success(let results):
+                    XCTAssertEqual([], results)
+                    expectation.fulfill()
+                  case .failure(let error):
+                    print(error)
+                    XCTFail()
+                    expectation.fulfill()
+                  }
                 }
 
-            case .failure:
-                XCTFail("Failed to add or replace Movies document")
-                expectation.fulfill()
+              }
+
+            case .failure(let error):
+              print(error)
+              XCTFail()
+              expectation.fulfill()
             }
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
+      case .failure:
+        XCTFail("Failed to add or replace Movies document")
+        expectation.fulfill()
+      }
     }
 
-    func testDeleteBatchDocuments() {
+    self.wait(for: [expectation], timeout: 10.0)
+  }
 
-        let documents: Data = try! JSONEncoder().encode(movies)
+  func testDeleteBatchDocuments() {
 
-        let expectation = XCTestExpectation(description: "Delete batch movies")
+    let documents: Data = try! JSONEncoder().encode(movies)
 
-        self.client.addDocuments(
-            UID: self.uid,
-            documents: documents,
-            primaryKey: nil
-        ) { result in
+    let expectation = XCTestExpectation(description: "Delete batch movies")
 
+    self.client.addDocuments(
+      UID: self.uid,
+      documents: documents,
+      primaryKey: nil
+    ) { result in
+
+      switch result {
+
+      case .success(let update):
+
+        XCTAssertEqual(Update(updateId: 0), update)
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          let idsToDelete: [Int] = [2, 1, 4]
+
+          self.client.deleteBatchDocuments(UID: self.uid, documentsUID: idsToDelete) { (result: Result<Update, Swift.Error>) in
             switch result {
 
             case .success(let update):
 
-                XCTAssertEqual(Update(updateId: 0), update)
+              XCTAssertEqual(Update(updateId: 1), update)
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              waitForPendingUpdate(self.client, self.uid, update) {
 
-                    let idsToDelete: [Int] = [2, 1, 4]
-
-                    self.client.deleteBatchDocuments(UID: self.uid, documentsUID: idsToDelete) { (result: Result<Update, Swift.Error>) in
-                        switch result {
-
-                        case .success(let update):
-
-                            XCTAssertEqual(Update(updateId: 1), update)
-
-                            waitForPendingUpdate(self.client, self.uid, update) {
-
-                                self.client.getDocuments(
-                                    UID: self.uid,
-                                    limit: 20
-                                ) { (result: Result<[Movie], Swift.Error>) in
-                                    switch result {
-                                    case .success(let results):
-                                        let filteredMovies: [Movie] = movies.filter { (movie: Movie) in !idsToDelete.contains(movie.id) }
-                                        XCTAssertEqual(filteredMovies, results)
-                                        expectation.fulfill()
-                                    case .failure(let error):
-                                        print(error)
-                                        XCTFail()
-                                    }
-                                }
-
-                            }
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                            expectation.fulfill()
-                        }
-                    }
-
+                self.client.getDocuments(
+                  UID: self.uid,
+                  limit: 20
+                ) { (result: Result<[Movie], Swift.Error>) in
+                  switch result {
+                  case .success(let results):
+                    let filteredMovies: [Movie] = movies.filter { (movie: Movie) in !idsToDelete.contains(movie.id) }
+                    XCTAssertEqual(filteredMovies, results)
+                    expectation.fulfill()
+                  case .failure(let error):
+                    print(error)
+                    XCTFail()
+                  }
                 }
 
-            case .failure:
-                XCTFail("Failed to delete batch movies")
-                expectation.fulfill()
+              }
+
+            case .failure(let error):
+              print(error)
+              XCTFail()
+              expectation.fulfill()
             }
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 5.0)
+      case .failure:
+        XCTFail("Failed to delete batch movies")
+        expectation.fulfill()
+      }
+
     }
 
-    static var allTests = [
-        ("testAddAndGetDocuments", testAddAndGetDocuments),
-        ("testAddDataAndGetDocuments", testAddDataAndGetDocuments),
-        ("testGetOneDocumentAndFail", testGetOneDocumentAndFail),
-        ("testAddAndGetOneDocumentWithIntIdentifierAndSucceed", testAddAndGetOneDocumentWithIntIdentifierAndSucceed),
-        ("testAddAndGetOneDocuments", testAddAndGetOneDocuments),
-        ("testUpdateAndGetDocuments", testUpdateAndGetDocuments),
-        ("testDeleteOneDocument", testDeleteOneDocument),
-        ("testDeleteAllDocuments", testDeleteAllDocuments),
-        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
-    ]
+    self.wait(for: [expectation], timeout: 5.0)
+  }
+
+  static var allTests = [
+    ("testAddAndGetDocuments", testAddAndGetDocuments),
+    ("testAddDataAndGetDocuments", testAddDataAndGetDocuments),
+    ("testGetOneDocumentAndFail", testGetOneDocumentAndFail),
+    ("testAddAndGetOneDocumentWithIntIdentifierAndSucceed", testAddAndGetOneDocumentWithIntIdentifierAndSucceed),
+    ("testAddAndGetOneDocuments", testAddAndGetOneDocuments),
+    ("testUpdateAndGetDocuments", testUpdateAndGetDocuments),
+    ("testDeleteOneDocument", testDeleteOneDocument),
+    ("testDeleteAllDocuments", testDeleteAllDocuments),
+    ("testDeleteBatchDocuments", testDeleteBatchDocuments)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
@@ -2,53 +2,55 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_try
 class DumpsTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
 
-    // MARK: Setup
+  // MARK: Setup
 
-    override func setUp() {
-        super.setUp()
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-        pool(client)
+  override func setUp() {
+    super.setUp()
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
+    pool(client)
+  }
 
-    func testCreateAndGetDump() {
+  func testCreateAndGetDump() {
 
-        let expectation = XCTestExpectation(description: "Request dump status")
+    let expectation = XCTestExpectation(description: "Request dump status")
 
-        self.client.createDump { result in
-            switch result {
-            case .success(let createDump):
+    self.client.createDump { result in
+      switch result {
+      case .success(let createDump):
 
-                XCTAssertTrue(!createDump.UID.isEmpty)
+        XCTAssertTrue(!createDump.UID.isEmpty)
 
-                self.client.getDumpStatus(UID: createDump.UID) { result in
-                    switch result {
-                    case .success(let dumpStatus):
-                        XCTAssertEqual(createDump.UID, dumpStatus.UID)
-                    case .failure(let error):
-                        XCTFail("Failed to request dump status \(error)")
-                    }
-                    expectation.fulfill()
-                }
-
-            case .failure(let error):
-                XCTFail("Failed to request dump creation \(error)")
-                expectation.fulfill()
-            }
+        self.client.getDumpStatus(UID: createDump.UID) { result in
+          switch result {
+          case .success(let dumpStatus):
+            XCTAssertEqual(createDump.UID, dumpStatus.UID)
+          case .failure(let error):
+            XCTFail("Failed to request dump status \(error)")
+          }
+          expectation.fulfill()
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
-
+      case .failure(let error):
+        XCTFail("Failed to request dump creation \(error)")
+        expectation.fulfill()
+      }
     }
 
-    static var allTests = [
-        ("testCreateAndGetDump", testCreateAndGetDump)
-    ]
+    self.wait(for: [expectation], timeout: 10.0)
+
+  }
+
+  static var allTests = [
+    ("testCreateAndGetDump", testCreateAndGetDump)
+  ]
 
 }
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/IndexesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/IndexesTests.swift
@@ -1,270 +1,272 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_try
 class IndexesTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+    super.setUp()
 
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-
-        pool(client)
-
-        let expectation = XCTestExpectation(description: "Try to delete index between tests")
-        self.client.deleteIndex(UID: self.uid) { _ in
-            expectation.fulfill()
-        }
-        self.wait(for: [expectation], timeout: 1.0)
-
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
 
-    func testCreateIndex() {
+    pool(client)
 
-        let createExpectation = XCTestExpectation(description: "Create Movies index")
+    let expectation = XCTestExpectation(description: "Try to delete index between tests")
+    self.client.deleteIndex(UID: self.uid) { _ in
+      expectation.fulfill()
+    }
+    self.wait(for: [expectation], timeout: 1.0)
 
-        self.client.createIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                createExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-        }
+  }
 
-        self.wait(for: [createExpectation], timeout: 1.0)
+  func testCreateIndex() {
+
+    let createExpectation = XCTestExpectation(description: "Create Movies index")
+
+    self.client.createIndex(UID: self.uid) { result in
+      switch result {
+      case .success(let index):
+        let stubIndex = Index(UID: self.uid)
+        XCTAssertEqual(stubIndex.UID, index.UID)
+        createExpectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get Movies index")
+      }
     }
 
-    func testGetOrCreateIndex() {
+    self.wait(for: [createExpectation], timeout: 1.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Get or create Movies index")
+  func testGetOrCreateIndex() {
 
-        self.client.getOrCreateIndex(UID: uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get or create Movies index")
-            }
-        }
+    let expectation = XCTestExpectation(description: "Get or create Movies index")
 
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getOrCreateIndex(UID: uid) { result in
+      switch result {
+      case .success(let index):
+          let stubIndex = Index(UID: self.uid)
+          XCTAssertEqual(stubIndex.UID, index.UID)
+          expectation.fulfill()
+      case .failure:
+          XCTFail("Failed to get or create Movies index")
+      }
     }
 
-    func testGetOrCreateIndexAlreadyExists() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        let expectation = XCTestExpectation(description: "Get or create a non existing uid")
+  }
 
-        self.client.getOrCreateIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                expectation.fulfill()
-            case .failure(let error):
-                XCTFail("Failed to get or create Movies index, error: \(error)")
-            }
-        }
+  func testGetOrCreateIndexAlreadyExists() {
 
-        self.wait(for: [expectation], timeout: 1.0)
+      let expectation = XCTestExpectation(description: "Get or create a non existing uid")
 
-        sleep(2)
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              expectation.fulfill()
+          case .failure(let error):
+              XCTFail("Failed to get or create Movies index, error: \(error)")
+          }
+      }
 
-        let SecondExpectation = XCTestExpectation(description: "Get or create an existing index")
+      self.wait(for: [expectation], timeout: 1.0)
 
-        self.client.getOrCreateIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                SecondExpectation.fulfill()
-            case .failure(let error):
-                XCTFail("Failed to get or create an existing index, error: \(error)")
-            }
-        }
+      sleep(2)
 
-        self.wait(for: [SecondExpectation], timeout: 1.0)
+      let secondExpectation = XCTestExpectation(description: "Get or create an existing index")
 
-    }
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              secondExpectation.fulfill()
+          case .failure(let error):
+              XCTFail("Failed to get or create an existing index, error: \(error)")
+          }
+      }
 
-    func testGetIndex() {
+      self.wait(for: [secondExpectation], timeout: 1.0)
 
-        let expectation = XCTestExpectation(description: "Get or create a non existing uid")
+  }
 
-        self.client.getOrCreateIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                expectation.fulfill()
-            case .failure(let error):
-                XCTFail("Failed to get or create Movies index, error: \(error)")
-            }
-        }
+  func testGetIndex() {
 
-        self.wait(for: [expectation], timeout: 1.0)
+      let expectation = XCTestExpectation(description: "Get or create a non existing uid")
 
-        let getIndexExpectation = XCTestExpectation(description: "Get index")
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              expectation.fulfill()
+          case .failure(let error):
+              XCTFail("Failed to get or create Movies index, error: \(error)")
+          }
+      }
 
-        self.client.getIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                getIndexExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get index")
-            }
+      self.wait(for: [expectation], timeout: 1.0)
 
-        }
+      let getIndexExpectation = XCTestExpectation(description: "Get index")
 
-        self.wait(for: [getIndexExpectation], timeout: 1.0)
+      self.client.getIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              getIndexExpectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get index")
+          }
 
-    }
+      }
 
-    func testGetIndexes() {
+      self.wait(for: [getIndexExpectation], timeout: 1.0)
 
-        let CreateIndexExpectation = XCTestExpectation(description: "Create Movies index")
+  }
 
-        self.client.createIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                CreateIndexExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-        }
+  func testGetIndexes() {
 
-        self.wait(for: [CreateIndexExpectation], timeout: 1.0)
+      let createIndexExpectation = XCTestExpectation(description: "Create Movies index")
 
-        sleep(1)
+      self.client.createIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              createIndexExpectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get Movies index")
+          }
+      }
 
-        let expectation = XCTestExpectation(description: "Load indexes")
+      self.wait(for: [createIndexExpectation], timeout: 1.0)
 
-        self.client.getIndexes { result in
+      sleep(1)
 
-            switch result {
-            case .success(let indexes):
-                let stubIndexes = [Index(UID: self.uid)]
-                XCTAssertEqual(stubIndexes.count, indexes.count)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get all Indexes")
-            }
+      let expectation = XCTestExpectation(description: "Load indexes")
 
-        }
+      self.client.getIndexes { result in
 
-        self.wait(for: [expectation], timeout: 1.0)
+          switch result {
+          case .success(let indexes):
+              let stubIndexes = [Index(UID: self.uid)]
+              XCTAssertEqual(stubIndexes.count, indexes.count)
+              expectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get all Indexes")
+          }
 
-    }
+      }
 
-    func testGetEmptyIndexes() {
+      self.wait(for: [expectation], timeout: 1.0)
 
-        let expectation = XCTestExpectation(description: "Load indexes")
+  }
 
-        self.client.getIndexes { result in
+  func testGetEmptyIndexes() {
 
-            switch result {
-            case .success(let indexes):
-                XCTAssertEqual([], indexes)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get all Indexes")
-            }
+      let expectation = XCTestExpectation(description: "Load indexes")
 
-        }
+      self.client.getIndexes { result in
 
-        self.wait(for: [expectation], timeout: 1.0)
+          switch result {
+          case .success(let indexes):
+              XCTAssertEqual([], indexes)
+              expectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get all Indexes")
+          }
 
-    }
+      }
 
-    func testUpdateIndexName() {
+      self.wait(for: [expectation], timeout: 1.0)
 
-        let createExpectation = XCTestExpectation(description: "Create Movies index")
+  }
 
-        self.client.createIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                createExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-        }
+  func testUpdateIndexName() {
 
-        self.wait(for: [createExpectation], timeout: 1.0)
+      let createExpectation = XCTestExpectation(description: "Create Movies index")
 
-        // This tests should tests primary key when they are added to this function
-        let updateExpectation = XCTestExpectation(description: "Update movie index")
-        self.client.updateIndex(UID: self.uid, primaryKey: "random") { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid, primaryKey: "random")
-                XCTAssertEqual(stubIndex.primaryKey, index.primaryKey)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                updateExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update movie index")
-            }
-        }
-        self.wait(for: [updateExpectation], timeout: 1.0)
-    }
+      self.client.createIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              createExpectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get Movies index")
+          }
+      }
 
-    func testDeleteIndex() {
+      self.wait(for: [createExpectation], timeout: 1.0)
 
-        let createExpectation = XCTestExpectation(description: "Create Movies index")
+      // This tests should tests primary key when they are added to this function
+      let updateExpectation = XCTestExpectation(description: "Update movie index")
+      self.client.updateIndex(UID: self.uid, primaryKey: "random") { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid, primaryKey: "random")
+              XCTAssertEqual(stubIndex.primaryKey, index.primaryKey)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              updateExpectation.fulfill()
+          case .failure:
+              XCTFail("Failed to update movie index")
+          }
+      }
+      self.wait(for: [updateExpectation], timeout: 1.0)
+  }
 
-        self.client.createIndex(UID: self.uid) { result in
-            switch result {
-            case .success(let index):
-                let stubIndex = Index(UID: self.uid)
-                XCTAssertEqual(stubIndex.UID, index.UID)
-                createExpectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-        }
+  func testDeleteIndex() {
 
-        self.wait(for: [createExpectation], timeout: 1.0)
+      let createExpectation = XCTestExpectation(description: "Create Movies index")
 
-        let expectation = XCTestExpectation(description: "Delete Movies index")
+      self.client.createIndex(UID: self.uid) { result in
+          switch result {
+          case .success(let index):
+              let stubIndex = Index(UID: self.uid)
+              XCTAssertEqual(stubIndex.UID, index.UID)
+              createExpectation.fulfill()
+          case .failure:
+              XCTFail("Failed to get Movies index")
+          }
+      }
 
-        self.client.deleteIndex(UID: self.uid) { result in
+      self.wait(for: [createExpectation], timeout: 1.0)
 
-            switch result {
-            case .success:
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete Movies index")
-            }
+      let expectation = XCTestExpectation(description: "Delete Movies index")
 
-        }
+      self.client.deleteIndex(UID: self.uid) { result in
 
-        self.wait(for: [expectation], timeout: 1.0)
+          switch result {
+          case .success:
+              expectation.fulfill()
+          case .failure:
+              XCTFail("Failed to delete Movies index")
+          }
 
-    }
+      }
 
-    static var allTests = [
-        ("testCreateIndex", testCreateIndex),
-        ("testGetOrCreateIndex", testGetOrCreateIndex),
-        ("testGetOrCreateIndexAlreadyExists", testGetOrCreateIndexAlreadyExists),
-        ("testGetIndex", testGetIndex),
-        ("testGetIndexes", testGetIndexes),
-        ("testGetEmptyIndexes", testGetEmptyIndexes),
-        ("testUpdateIndexName", testUpdateIndexName),
-        ("testDeleteIndex", testDeleteIndex)
-    ]
+      self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testCreateIndex", testCreateIndex),
+    ("testGetOrCreateIndex", testGetOrCreateIndex),
+    ("testGetOrCreateIndexAlreadyExists", testGetOrCreateIndexAlreadyExists),
+    ("testGetIndex", testGetIndex),
+    ("testGetIndexes", testGetIndexes),
+    ("testGetEmptyIndexes", testGetEmptyIndexes),
+    ("testUpdateIndexName", testUpdateIndexName),
+    ("testDeleteIndex", testDeleteIndex)
+  ]
 
 }
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/Pooling.swift
+++ b/Tests/MeiliSearchIntegrationTests/Pooling.swift
@@ -11,52 +11,52 @@ import XCTest
 
 public func pool(_ client: MeiliSearch) {
 
-    autoreleasepool {
+  autoreleasepool {
 
-        let semaphore = DispatchSemaphore(value: 0)
-        var success: Bool = false
+    let semaphore = DispatchSemaphore(value: 0)
+    var success: Bool = false
 
-        while true {
-            client.health { result in
-                switch result {
-                case .success:
-                    success = true
-                case .failure:
-                    Thread.sleep(forTimeInterval: 0.5)
-                    success = false
-                }
-                semaphore.signal()
-            }
-            if !success {
-                semaphore.wait()
-                continue
-            }
-            break
+    while true {
+      client.health { result in
+        switch result {
+        case .success:
+          success = true
+        case .failure:
+          Thread.sleep(forTimeInterval: 0.5)
+          success = false
         }
-
+        semaphore.signal()
+      }
+      if !success {
+        semaphore.wait()
+        continue
+      }
+      break
     }
+
+  }
 
 }
 
 public func waitForPendingUpdate(
-    _ client: MeiliSearch,
-    _ UID: String,
-    _ update: Update,
-    _ completion: @escaping () -> Void) {
-    func request() {
-        client.getUpdate(UID: UID, update) { result in
-            switch result {
-            case .success(let updateResult):
-                if updateResult.status == Update.Status.processed {
-                    completion()
-                    return
-                }
-                request()
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
+  _ client: MeiliSearch,
+  _ UID: String,
+  _ update: Update,
+  _ completion: @escaping () -> Void) {
+  func request() {
+    client.getUpdate(UID: UID, update) { result in
+      switch result {
+      case .success(let updateResult):
+        if updateResult.status == Update.Status.processed {
+          completion()
+          return
         }
+        request()
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
-    request()
+  }
+  request()
 }

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -2,681 +2,685 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 private struct Book: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let comment: String?
-    let genres: [String]?
-    let formatted: FormattedBook?
-    let matchesInfo: MatchesInfoBook?
+  let id: Int
+  let title: String
+  let comment: String?
+  let genres: [String]?
+  let formatted: FormattedBook?
+  let matchesInfo: MatchesInfoBook?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case comment
-        case genres
-        case formatted = "_formatted"
-        case matchesInfo = "_matchesInfo"
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+    case genres
+    case formatted = "_formatted"
+    case matchesInfo = "_matchesInfo"
+  }
 
-    init(id: Int, title: String, comment: String? = nil, genres: [String] = [],
-         formatted: FormattedBook? = nil, matchesInfo: MatchesInfoBook? = nil) {
-        self.id = id
-        self.title = title
-        self.comment = comment
-        self.genres = genres
-        self.formatted = formatted
-        self.matchesInfo = matchesInfo
-    }
+  init(id: Int, title: String, comment: String? = nil, genres: [String] = [],
+       formatted: FormattedBook? = nil, matchesInfo: MatchesInfoBook? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+    self.genres = genres
+    self.formatted = formatted
+    self.matchesInfo = matchesInfo
+  }
 
 }
 
 private struct FormattedBook: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let comment: String?
+  let id: Int
+  let title: String
+  let comment: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case comment
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+  }
 
-    init(id: Int, title: String, comment: String? = nil) {
-        self.id = id
-        self.title = title
-        self.comment = comment
-    }
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+  }
 
 }
 
 private struct MatchesInfoBook: Codable, Equatable {
-    let comment: [Info]
-    enum CodingKeys: String, CodingKey {
-        case comment
-    }
+  let comment: [Info]
+  enum CodingKeys: String, CodingKey {
+    case comment
+  }
 }
 
 private struct Info: Codable, Equatable {
-    let start: Int
-    let length: Int
-    enum CodingKeys: String, CodingKey {
-        case start
-        case length
-    }
+  let start: Int
+  let length: Int
+  enum CodingKeys: String, CodingKey {
+    case start
+    case length
+  }
 }
 
 private let books: [Book] = [
-    Book(id: 123, title: "Pride and Prejudice", comment: "A great book", genres: ["Classic Regency nove"]),
-    Book(id: 456, title: "Le Petit Prince", comment: "A french book", genres: ["Novel"]),
-    Book(id: 2, title: "Le Rouge et le Noir", comment: "Another french book", genres: ["Bildungsroman"]),
-    Book(id: 1, title: "Alice In Wonderland", comment: "A weird book", genres: ["Fantasy"]),
-    Book(id: 1344, title: "The Hobbit", comment: "An awesome book", genres: ["High fantasy‎"]),
-    Book(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book", genres: ["Fantasy"]),
-    Book(id: 42, title: "The Hitchhiker's Guide to the Galaxy", genres: ["Novel"]),
-    Book(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo", genres: ["Novel"])
+  Book(id: 123, title: "Pride and Prejudice", comment: "A great book", genres: ["Classic Regency nove"]),
+  Book(id: 456, title: "Le Petit Prince", comment: "A french book", genres: ["Novel"]),
+  Book(id: 2, title: "Le Rouge et le Noir", comment: "Another french book", genres: ["Bildungsroman"]),
+  Book(id: 1, title: "Alice In Wonderland", comment: "A weird book", genres: ["Fantasy"]),
+  Book(id: 1344, title: "The Hobbit", comment: "An awesome book", genres: ["High fantasy‎"]),
+  Book(id: 4, title: "Harry Potter and the Half-Blood Prince", comment: "The best book", genres: ["Fantasy"]),
+  Book(id: 42, title: "The Hitchhiker's Guide to the Galaxy", genres: ["Novel"]),
+  Book(id: 1844, title: "A Moreninha", comment: "A Book from Joaquim Manuel de Macedo", genres: ["Novel"])
 ]
 
 class SearchTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
 
-    // MARK: Setup
+  // MARK: Setup
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+    super.setUp()
 
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-
-        pool(client)
-
-        let documents: Data = try! JSONEncoder().encode(books)
-
-        let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.deleteIndex(UID: uid) { result in
-
-            self.client.getOrCreateIndex(UID: self.uid) { result in
-
-                switch result {
-                case .success:
-
-                    self.client.addDocuments(
-                        UID: self.uid,
-                        documents: documents,
-                        primaryKey: nil
-                    ) { result in
-
-                        switch result {
-                        case .success(let update):
-                            waitForPendingUpdate(self.client, self.uid, update) {
-                                expectation.fulfill()
-                            }
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                            expectation.fulfill()
-                        }
-
-                    }
-
-                case .failure(let error):
-                    print(error)
-                    XCTFail()
-                }
-
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
 
-    // MARK: Basic search
+    pool(client)
 
-    func testBasicSearch() {
+    let documents: Data = try! JSONEncoder().encode(books)
 
-        let expectation = XCTestExpectation(description: "Search for Books using limit")
+    let expectation = XCTestExpectation(description: "Create index if it does not exist")
 
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        // let limit = 5
-        let query = "A Moreninha"
+    self.client.deleteIndex(UID: uid) { result in
 
-        self.client.search(UID: self.uid, SearchParameters(query: query)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == 20)
-                XCTAssertTrue(documents.hits.count == 1)
-                XCTAssertEqual(query, documents.hits[0].title)
-                XCTAssertNil(documents.hits[0].formatted)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testBasicSearch")
-            }
-        }
+      self.client.getOrCreateIndex(UID: self.uid) { result in
 
-        self.wait(for: [expectation], timeout: 1.0)
-    }
+        switch result {
+        case .success:
 
-    func testBasicSearchWithNoQuery() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using limit")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-
-        self.client.search(UID: self.uid, SearchParameters(query: nil)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertEqual("", documents.query)
-                XCTAssertEqual(20, documents.limit)
-                XCTAssertEqual(books.count, documents.hits.count)
-                XCTAssertEqual("Pride and Prejudice", documents.hits[0].title)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testBasicSearchWithNoQuery")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Limit
-
-    func testSearchLimit() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using limit")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "A Moreninha"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 1)
-                XCTAssertEqual(query, documents.hits[0].title)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchLimit")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchZeroLimit() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using zero limit")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 0
-        let query = "A Moreninha"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.isEmpty)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchZeroLimit")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchLimitBiggerThanNumberOfBooks() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using limit bigger than the number of books stored")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "A"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == limit)
-                XCTAssertNil(documents.hits[0].formatted)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchLimitBiggerThanNumberOfBooks")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchLimitEmptySearch() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using limit but nothing in the query")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = ""
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 5)
-                XCTAssertNil(documents.hits[0].formatted)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchLimitEmptySearch")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Offset
-
-    func testSearchOffset() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using offset")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 2
-        let offset = 2
-        let query = "A"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.offset == offset)
-                XCTAssertTrue(documents.hits.count == 2)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchOffset")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchOffsetZero() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using zero offset")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 2
-        let offset = 0
-        let query = "A"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.offset == offset)
-                XCTAssertTrue(documents.hits.count == 2)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchOffsetZero")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchOffsetLastPage() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using a offset at the last page")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 2
-        let offset = 6
-        let query = "A"
-
-        self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.offset == offset)
-                XCTAssertTrue(documents.hits.count == 1)
-                XCTAssertNil(documents.hits[0].formatted)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchOffsetLastPage")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Attributes to crop
-
-    func testSearchAttributesToCrop() {
-
-      let expectation = XCTestExpectation(description: "Search for Books using attributes to crop")
-
-      typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-      let limit = 2
-      let query = "de Macedo"
-      let attributesToCrop = ["comment"]
-      let cropLength = 10
-      let searchParameters = SearchParameters(query: query, limit: limit, attributesToCrop: attributesToCrop, cropLength: cropLength)
-
-      self.client.search(UID: self.uid, searchParameters) { (result: MeiliResult) in
-          switch result {
-          case .success(let documents):
-              XCTAssertTrue(documents.limit == limit)
-              XCTAssertTrue(documents.hits.count == 1)
-              let book: Book = documents.hits[0]
-              XCTAssertEqual("Manuel de Macedo", book.formatted!.comment!)
-              expectation.fulfill()
-          case .failure:
-              XCTFail("Failed to search with testSearchAttributesToCrop")
-          }
-      }
-
-      self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Crop length
-
-    func testSearchCropLength() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using default crop length")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 2
-        let query = "book"
-        let attributesToCrop = ["comment"]
-        let cropLength = 10
-        let searchParameters = SearchParameters(query: query, limit: limit, attributesToCrop: attributesToCrop, cropLength: cropLength)
-
-        self.client.search(UID: self.uid, searchParameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 2)
-
-                let moreninhaBook: Book = documents.hits.first(where: { book in book.id == 1844 })!
-                let prideBook: Book = documents.hits.first(where: { book in book.id == 123 })!
-
-                XCTAssertEqual("A Book from", moreninhaBook.formatted!.comment!)
-                XCTAssertEqual("A great book", prideBook.formatted!.comment!)
-
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchCropLength")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Matches tests
-
-    func testSearchMatches() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using matches")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "A Moreninha"
-        let parameters = SearchParameters(query: query, limit: limit, matches: true)
-
-        self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 1)
-                let book = documents.hits[0]
-                XCTAssertEqual(query, book.title)
-                let matchesInfo = book.matchesInfo!
-                XCTAssertFalse(matchesInfo.comment.isEmpty)
-                let info = matchesInfo.comment[0]
-                XCTAssertEqual(0, info.start)
-                XCTAssertEqual(1, info.length)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchMatches")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Attributes to highlight
-
-    func testSearchAttributesToHighlight() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using attributes to highlight")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "Joaquim Manuel de Macedo"
-        let attributesToHighlight = ["comment"]
-        let parameters = SearchParameters(query: query, limit: limit, attributesToHighlight: attributesToHighlight)
-
-        self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 1)
-                let book = documents.hits[0]
-                XCTAssertEqual("A Moreninha", book.title)
-                XCTAssertTrue(book.formatted!.comment!.contains("<em>Joaquim</em> <em>Manuel</em> <em>de</em> <em>Macedo</em>"))
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchAttributesToHighlight")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Attributes to retrieve
-
-    func testSearchAttributesToRetrieve() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using attributes to retrieve")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "Joaquim Manuel de Macedo"
-        let attributesToRetrieve = ["id", "title"]
-        let parameters = SearchParameters(query: query, limit: limit, attributesToRetrieve: attributesToRetrieve)
-
-        self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 1)
-                let book = documents.hits[0]
-                XCTAssertEqual(1844, book.id)
-                XCTAssertEqual("A Moreninha", book.title)
-                XCTAssertNil(book.comment)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchAttributesToRetrieve")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Filters
-
-    func testSearchFilters() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using filters")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "french book"
-        let filters = "id = 456"
-        let parameters = SearchParameters(query: query, limit: limit, filters: filters)
-
-        self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.count == 1)
-                let book = documents.hits[0]
-                XCTAssertEqual(456, book.id)
-                XCTAssertEqual("Le Petit Prince", book.title)
-                XCTAssertEqual("A french book", book.comment)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchFilters")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testSearchFiltersNotMatching() {
-
-        let expectation = XCTestExpectation(description: "Search for Books using filters but the query and filters are not matching")
-
-        typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-        let limit = 5
-        let query = "Joaquim Manuel de Macedo"
-        let filters = "id = 456"
-        let parameters = SearchParameters(query: query, limit: limit, filters: filters)
-
-        self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let documents):
-                XCTAssertTrue(documents.query == query)
-                XCTAssertTrue(documents.limit == limit)
-                XCTAssertTrue(documents.hits.isEmpty)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search with testSearchFiltersNotMatching")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Facets filters
-
-    private func configureFacets(_ completion: @escaping () -> Void) {
-
-        let expectation = XCTestExpectation(description: "Configure attributes for faceting")
-        let attributesForFaceting = ["genres", "author"]
-
-        self.client.updateAttributesForFaceting(UID: self.uid, attributesForFaceting) { result in
+          self.client.addDocuments(
+            UID: self.uid,
+            documents: documents,
+            primaryKey: nil
+          ) { result in
 
             switch result {
             case .success(let update):
-                waitForPendingUpdate(self.client, self.uid, update) {
-                    expectation.fulfill()
-                    completion()
-                }
-            case .failure:
-                XCTFail("Failed to update the settings")
+              waitForPendingUpdate(self.client, self.uid, update) {
+                expectation.fulfill()
+              }
+            case .failure(let error):
+              print(error)
+              XCTFail()
+              expectation.fulfill()
             }
 
+          }
+
+        case .failure(let error):
+          print(error)
+          XCTFail()
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      }
 
     }
 
-    func testSearchFacetsFilters() {
+    self.wait(for: [expectation], timeout: 10.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Search for Books using facets filters")
+  // MARK: Basic search
 
-        configureFacets {
+  func testBasicSearch() {
 
-            typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-            let limit = 5
-            let query = "A"
-            let facetsFilters = [["genres:Novel"]]
-            let parameters = SearchParameters(query: query, limit: limit, facetFilters: facetsFilters)
+    let expectation = XCTestExpectation(description: "Search for Books using limit")
 
-            self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-                switch result {
-                case .success(let documents):
-                    XCTAssertTrue(documents.query == query)
-                    XCTAssertTrue(documents.limit == limit)
-                    XCTAssertTrue(documents.hits.count == 2)
-                    let moreninhaBook: Book = documents.hits.first { book in book.id == 1844 }!
-                    XCTAssertEqual("A Moreninha", moreninhaBook.title)
-                    let petitBook: Book = documents.hits.first { book in book.id == 456 }!
-                    XCTAssertEqual("Le Petit Prince", petitBook.title)
-                    expectation.fulfill()
-                case .failure:
-                    XCTFail("Failed to search with testSearchFacetsFilters")
-                }
-            }
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    // let limit = 5
+    let query = "A Moreninha"
 
-        }
-
-        self.wait(for: [expectation], timeout: 2.0)
+    self.client.search(UID: self.uid, SearchParameters(query: query)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == 20)
+        XCTAssertTrue(documents.hits.count == 1)
+        XCTAssertEqual(query, documents.hits[0].title)
+        XCTAssertNil(documents.hits[0].formatted)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testBasicSearch")
+      }
     }
 
-    // MARK: Facets distribution
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-    func testSearchFacetsDistribution() {
+  func testBasicSearchWithNoQuery() {
 
-        let expectation = XCTestExpectation(description: "Search for Books using facets distribution")
+    let expectation = XCTestExpectation(description: "Search for Books using limit")
 
-        configureFacets {
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
 
-            typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
-            let limit = 5
-            let query = "A"
-            let facetsDistribution = ["genres"]
-            let parameters = SearchParameters(query: query, limit: limit, facetsDistribution: facetsDistribution)
-
-            self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
-                switch result {
-                case .success(let documents):
-                    XCTAssertTrue(documents.query == query)
-                    XCTAssertTrue(documents.limit == limit)
-                    XCTAssertTrue(documents.hits.count == limit)
-
-                    let facetsDistribution = documents.facetsDistribution!
-
-                    let expected: [String: [String: Int]] = [
-                        "genres": [
-                            "Classic Regency nove": 1,
-                            "High fantasy‎": 1,
-                            "Fantasy": 2,
-                            "Novel": 2,
-                            "Bildungsroman": 1
-                        ]
-                    ]
-
-                    XCTAssertEqual(expected, facetsDistribution)
-
-                    expectation.fulfill()
-                case .failure:
-                    XCTFail("Failed to search with testSearchFacetsDistribution")
-                }
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 2.0)
+    self.client.search(UID: self.uid, SearchParameters(query: nil)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertEqual("", documents.query)
+        XCTAssertEqual(20, documents.limit)
+        XCTAssertEqual(books.count, documents.hits.count)
+        XCTAssertEqual("Pride and Prejudice", documents.hits[0].title)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testBasicSearchWithNoQuery")
+      }
     }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Limit
+
+  func testSearchLimit() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using limit")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "A Moreninha"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        XCTAssertEqual(query, documents.hits[0].title)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchLimit")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchZeroLimit() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using zero limit")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 0
+    let query = "A Moreninha"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.isEmpty)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchZeroLimit")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchLimitBiggerThanNumberOfBooks() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using limit bigger than the number of books stored")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "A"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == limit)
+        XCTAssertNil(documents.hits[0].formatted)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchLimitBiggerThanNumberOfBooks")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchLimitEmptySearch() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using limit but nothing in the query")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = ""
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 5)
+        XCTAssertNil(documents.hits[0].formatted)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchLimitEmptySearch")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Offset
+
+  func testSearchOffset() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using offset")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 2
+    let offset = 2
+    let query = "A"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.offset == offset)
+        XCTAssertTrue(documents.hits.count == 2)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchOffset")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchOffsetZero() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using zero offset")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 2
+    let offset = 0
+    let query = "A"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.offset == offset)
+        XCTAssertTrue(documents.hits.count == 2)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchOffsetZero")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchOffsetLastPage() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using a offset at the last page")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 2
+    let offset = 6
+    let query = "A"
+
+    self.client.search(UID: self.uid, SearchParameters(query: query, offset: offset, limit: limit)) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.offset == offset)
+        XCTAssertTrue(documents.hits.count == 1)
+        XCTAssertNil(documents.hits[0].formatted)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchOffsetLastPage")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Attributes to crop
+
+  func testSearchAttributesToCrop() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using attributes to crop")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 2
+    let query = "de Macedo"
+    let attributesToCrop = ["comment"]
+    let cropLength = 10
+    let searchParameters = SearchParameters(query: query, limit: limit, attributesToCrop: attributesToCrop, cropLength: cropLength)
+
+    self.client.search(UID: self.uid, searchParameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        let book: Book = documents.hits[0]
+        XCTAssertEqual("Manuel de Macedo", book.formatted!.comment!)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchAttributesToCrop")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Crop length
+
+  func testSearchCropLength() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using default crop length")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 2
+    let query = "book"
+    let attributesToCrop = ["comment"]
+    let cropLength = 10
+    let searchParameters = SearchParameters(query: query, limit: limit, attributesToCrop: attributesToCrop, cropLength: cropLength)
+
+    self.client.search(UID: self.uid, searchParameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 2)
+
+        let moreninhaBook: Book = documents.hits.first(where: { book in book.id == 1844 })!
+        let prideBook: Book = documents.hits.first(where: { book in book.id == 123 })!
+
+        XCTAssertEqual("A Book from", moreninhaBook.formatted!.comment!)
+        XCTAssertEqual("A great book", prideBook.formatted!.comment!)
+
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchCropLength")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Matches tests
+
+  func testSearchMatches() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using matches")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "A Moreninha"
+    let parameters = SearchParameters(query: query, limit: limit, matches: true)
+
+    self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        let book = documents.hits[0]
+        XCTAssertEqual(query, book.title)
+        let matchesInfo = book.matchesInfo!
+        XCTAssertFalse(matchesInfo.comment.isEmpty)
+        let info = matchesInfo.comment[0]
+        XCTAssertEqual(0, info.start)
+        XCTAssertEqual(1, info.length)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchMatches")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Attributes to highlight
+
+  func testSearchAttributesToHighlight() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using attributes to highlight")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "Joaquim Manuel de Macedo"
+    let attributesToHighlight = ["comment"]
+    let parameters = SearchParameters(query: query, limit: limit, attributesToHighlight: attributesToHighlight)
+
+    self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        let book = documents.hits[0]
+        XCTAssertEqual("A Moreninha", book.title)
+        XCTAssertTrue(book.formatted!.comment!.contains("<em>Joaquim</em> <em>Manuel</em> <em>de</em> <em>Macedo</em>"))
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchAttributesToHighlight")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Attributes to retrieve
+
+  func testSearchAttributesToRetrieve() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using attributes to retrieve")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "Joaquim Manuel de Macedo"
+    let attributesToRetrieve = ["id", "title"]
+    let parameters = SearchParameters(query: query, limit: limit, attributesToRetrieve: attributesToRetrieve)
+
+    self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        let book = documents.hits[0]
+        XCTAssertEqual(1844, book.id)
+        XCTAssertEqual("A Moreninha", book.title)
+        XCTAssertNil(book.comment)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchAttributesToRetrieve")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Filters
+
+  func testSearchFilters() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using filters")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "french book"
+    let filters = "id = 456"
+    let parameters = SearchParameters(query: query, limit: limit, filters: filters)
+
+    self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.count == 1)
+        let book = documents.hits[0]
+        XCTAssertEqual(456, book.id)
+        XCTAssertEqual("Le Petit Prince", book.title)
+        XCTAssertEqual("A french book", book.comment)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchFilters")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testSearchFiltersNotMatching() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using filters but the query and filters are not matching")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let limit = 5
+    let query = "Joaquim Manuel de Macedo"
+    let filters = "id = 456"
+    let parameters = SearchParameters(query: query, limit: limit, filters: filters)
+
+    self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        XCTAssertTrue(documents.query == query)
+        XCTAssertTrue(documents.limit == limit)
+        XCTAssertTrue(documents.hits.isEmpty)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search with testSearchFiltersNotMatching")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  // MARK: Facets filters
+
+  private func configureFacets(_ completion: @escaping () -> Void) {
+
+    let expectation = XCTestExpectation(description: "Configure attributes for faceting")
+    let attributesForFaceting = ["genres", "author"]
+
+    self.client.updateAttributesForFaceting(UID: self.uid, attributesForFaceting) { result in
+
+      switch result {
+      case .success(let update):
+        waitForPendingUpdate(self.client, self.uid, update) {
+          expectation.fulfill()
+          completion()
+        }
+      case .failure:
+        XCTFail("Failed to update the settings")
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  func testSearchFacetsFilters() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using facets filters")
+
+    configureFacets {
+
+      typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+      let limit = 5
+      let query = "A"
+      let facetsFilters = [["genres:Novel"]]
+      let parameters = SearchParameters(query: query, limit: limit, facetFilters: facetsFilters)
+
+      self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+        switch result {
+        case .success(let documents):
+          XCTAssertTrue(documents.query == query)
+          XCTAssertTrue(documents.limit == limit)
+          XCTAssertTrue(documents.hits.count == 2)
+          let moreninhaBook: Book = documents.hits.first { book in book.id == 1844 }!
+          XCTAssertEqual("A Moreninha", moreninhaBook.title)
+          let petitBook: Book = documents.hits.first { book in book.id == 456 }!
+          XCTAssertEqual("Le Petit Prince", petitBook.title)
+          expectation.fulfill()
+        case .failure:
+          XCTFail("Failed to search with testSearchFacetsFilters")
+        }
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 2.0)
+  }
+
+  // MARK: Facets distribution
+
+  func testSearchFacetsDistribution() {
+
+    let expectation = XCTestExpectation(description: "Search for Books using facets distribution")
+
+    configureFacets {
+
+      typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+      let limit = 5
+      let query = "A"
+      let facetsDistribution = ["genres"]
+      let parameters = SearchParameters(query: query, limit: limit, facetsDistribution: facetsDistribution)
+
+      self.client.search(UID: self.uid, parameters) { (result: MeiliResult) in
+        switch result {
+        case .success(let documents):
+          XCTAssertTrue(documents.query == query)
+          XCTAssertTrue(documents.limit == limit)
+          XCTAssertTrue(documents.hits.count == limit)
+
+          let facetsDistribution = documents.facetsDistribution!
+
+          let expected: [String: [String: Int]] = [
+            "genres": [
+              "Classic Regency nove": 1,
+              "High fantasy‎": 1,
+              "Fantasy": 2,
+              "Novel": 2,
+              "Bildungsroman": 1
+            ]
+          ]
+
+          XCTAssertEqual(expected, facetsDistribution)
+
+          expectation.fulfill()
+        case .failure:
+          XCTFail("Failed to search with testSearchFacetsDistribution")
+        }
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -2,880 +2,882 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_try
 class SettingsTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
-    private let defaultRankingRules: [String] = [
-        "typo",
-        "words",
-        "proximity",
-        "attribute",
-        "wordsPosition",
-        "exactness"
-    ]
-    private let defaultDistinctAttribute: String? = nil
-    private let defaultDisplayedAttributes: [String] = ["*"]
-    private let defaultSearchableAttributes: [String] = ["*"]
-    private let defaultAttributesForFaceting: [String] = []
-    private let defaultStopWords: [String] = []
-    private let defaultSynonyms: [String: [String]] = [:]
-    private var defaultGlobalSettings: Setting?
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
+  private let defaultRankingRules: [String] = [
+    "typo",
+    "words",
+    "proximity",
+    "attribute",
+    "wordsPosition",
+    "exactness"
+  ]
+  private let defaultDistinctAttribute: String? = nil
+  private let defaultDisplayedAttributes: [String] = ["*"]
+  private let defaultSearchableAttributes: [String] = ["*"]
+  private let defaultAttributesForFaceting: [String] = []
+  private let defaultStopWords: [String] = []
+  private let defaultSynonyms: [String: [String]] = [:]
+  private var defaultGlobalSettings: Setting?
 
-    // MARK: Setup
+  // MARK: Setup
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+    super.setUp()
 
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-
-        pool(client)
-
-        let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.deleteIndex(UID: uid) { _ in
-            self.client.getOrCreateIndex(UID: self.uid) { result in
-                switch result {
-                case .success:
-                    expectation.fulfill()
-                case .failure(let error):
-                    print(error)
-                    XCTFail()
-                }
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
-
-        self.defaultGlobalSettings = Setting(
-            rankingRules: self.defaultRankingRules,
-            searchableAttributes: self.defaultSearchableAttributes,
-            displayedAttributes: self.defaultDisplayedAttributes,
-            stopWords: self.defaultStopWords,
-            synonyms: self.defaultSynonyms,
-            distinctAttribute: self.defaultDistinctAttribute,
-            attributesForFaceting: self.defaultAttributesForFaceting
-        )
-
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
 
-    // MARK: Attributes for faceting
+    pool(client)
 
-    func testGetAttributesForFaceting() {
+    let expectation = XCTestExpectation(description: "Create index if it does not exist")
 
-        let expectation = XCTestExpectation(description: "Get current attributes for faceting")
-
-        self.client.getAttributesForFaceting(UID: self.uid) { result in
-            switch result {
-            case .success(let attributes):
-
-                XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
-
-                expectation.fulfill()
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
+    self.client.deleteIndex(UID: uid) { _ in
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+        switch result {
+        case .success:
+          expectation.fulfill()
+        case .failure(let error):
+          print(error)
+          XCTFail()
         }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      }
     }
 
-    func testUpdateAttributesForFaceting() {
+    self.wait(for: [expectation], timeout: 10.0)
 
-        let expectation = XCTestExpectation(description: "Update settings for attributes for faceting")
+    self.defaultGlobalSettings = Setting(
+      rankingRules: self.defaultRankingRules,
+      searchableAttributes: self.defaultSearchableAttributes,
+      displayedAttributes: self.defaultDisplayedAttributes,
+      stopWords: self.defaultStopWords,
+      synonyms: self.defaultSynonyms,
+      distinctAttribute: self.defaultDistinctAttribute,
+      attributesForFaceting: self.defaultAttributesForFaceting
+    )
 
-        let newAttributesForFaceting: [String] = ["title"]
+  }
 
-        self.client.updateAttributesForFaceting(UID: self.uid, newAttributesForFaceting) { result in
-            switch result {
-            case .success(let update):
+  // MARK: Attributes for faceting
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+  func testGetAttributesForFaceting() {
 
-                    self.client.getAttributesForFaceting(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Get current attributes for faceting")
 
-                        switch result {
-                        case .success(let attributes):
+    self.client.getAttributesForFaceting(UID: self.uid) { result in
+      switch result {
+      case .success(let attributes):
 
-                            XCTAssertEqual(newAttributesForFaceting, attributes)
+        XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
 
-                            expectation.fulfill()
+        expectation.fulfill()
 
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 2.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testResetAttributesForFaceting() {
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset settings for attributes for faceting")
+  func testUpdateAttributesForFaceting() {
 
-        self.client.resetAttributesForFaceting(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Update settings for attributes for faceting")
 
-            switch result {
-            case .success(let update):
+    let newAttributesForFaceting: [String] = ["title"]
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+    self.client.updateAttributesForFaceting(UID: self.uid, newAttributesForFaceting) { result in
+      switch result {
+      case .success(let update):
 
-                    self.client.getAttributesForFaceting(UID: self.uid) { result in
+        waitForPendingUpdate(self.client, self.uid, update) {
 
-                        switch result {
-                        case .success(let attributes):
-
-                            XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Displayed attributes
-
-    func testGetDisplayedAttributes() {
-
-        let expectation = XCTestExpectation(description: "Get current displayed attributes")
-
-        self.client.getDisplayedAttributes(UID: self.uid) { result in
+          self.client.getAttributesForFaceting(UID: self.uid) { result in
 
             switch result {
             case .success(let attributes):
 
-                XCTAssertEqual(self.defaultDisplayedAttributes, attributes)
+              XCTAssertEqual(newAttributesForFaceting, attributes)
 
-                expectation.fulfill()
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testUpdateDisplayedAttributes() {
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Update settings for displayed attributes")
+  func testResetAttributesForFaceting() {
 
-        let newDisplayedAttributes: [String] = ["title"]
+    let expectation = XCTestExpectation(description: "Reset settings for attributes for faceting")
 
-        self.client.updateDisplayedAttributes(UID: self.uid, newDisplayedAttributes) { result in
-            switch result {
-            case .success(let update):
+    self.client.resetAttributesForFaceting(UID: self.uid) { result in
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+      switch result {
+      case .success(let update):
 
-                    self.client.getDisplayedAttributes(UID: self.uid) { result in
+        waitForPendingUpdate(self.client, self.uid, update) {
 
-                        switch result {
-                        case .success(let attributes):
-
-                            XCTAssertEqual(newDisplayedAttributes, attributes)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
-    }
-
-    func testResetDisplayedAttributes() {
-
-        let expectation = XCTestExpectation(description: "Reset settings for displayed attributes")
-
-        self.client.resetDisplayedAttributes(UID: self.uid) { result in
+          self.client.getAttributesForFaceting(UID: self.uid) { result in
 
             switch result {
-            case .success(let update):
+            case .success(let attributes):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getDisplayedAttributes(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let attribute):
-
-                            XCTAssertEqual(self.defaultDisplayedAttributes, attribute)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              XCTAssertEqual(self.defaultAttributesForFaceting, attributes)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    // MARK: Distinct attributes
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-    func testGetDistinctAttribute() {
+  // MARK: Displayed attributes
 
-        let expectation = XCTestExpectation(description: "Get current distinct attribute")
+  func testGetDisplayedAttributes() {
 
-        self.client.getDistinctAttribute(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Get current displayed attributes")
+
+    self.client.getDisplayedAttributes(UID: self.uid) { result in
+
+      switch result {
+      case .success(let attributes):
+
+        XCTAssertEqual(self.defaultDisplayedAttributes, attributes)
+
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateDisplayedAttributes() {
+
+    let expectation = XCTestExpectation(description: "Update settings for displayed attributes")
+
+    let newDisplayedAttributes: [String] = ["title"]
+
+    self.client.updateDisplayedAttributes(UID: self.uid, newDisplayedAttributes) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDisplayedAttributes(UID: self.uid) { result in
+
+            switch result {
+            case .success(let attributes):
+
+              XCTAssertEqual(newDisplayedAttributes, attributes)
+              expectation.fulfill()
+
+            case .failure(let error):
+              print(error)
+              XCTFail()
+            }
+
+          }
+
+        }
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 10.0)
+  }
+
+  func testResetDisplayedAttributes() {
+
+    let expectation = XCTestExpectation(description: "Reset settings for displayed attributes")
+
+    self.client.resetDisplayedAttributes(UID: self.uid) { result in
+
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDisplayedAttributes(UID: self.uid) { result in
 
             switch result {
             case .success(let attribute):
 
-                XCTAssertEqual(self.defaultDistinctAttribute, attribute)
-
-                expectation.fulfill()
+              XCTAssertEqual(self.defaultDisplayedAttributes, attribute)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testUpdateDistinctAttribute() {
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Update settings for distinct attribute")
+  // MARK: Distinct attributes
 
-        let newDistinctAttribute: String = "title"
+  func testGetDistinctAttribute() {
 
-        self.client.updateDistinctAttribute(UID: self.uid, newDistinctAttribute) { result in
+    let expectation = XCTestExpectation(description: "Get current distinct attribute")
+
+    self.client.getDistinctAttribute(UID: self.uid) { result in
+
+      switch result {
+      case .success(let attribute):
+
+        XCTAssertEqual(self.defaultDistinctAttribute, attribute)
+
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateDistinctAttribute() {
+
+    let expectation = XCTestExpectation(description: "Update settings for distinct attribute")
+
+    let newDistinctAttribute: String = "title"
+
+    self.client.updateDistinctAttribute(UID: self.uid, newDistinctAttribute) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDistinctAttribute(UID: self.uid) { result in
+
             switch result {
-            case .success(let update):
+            case .success(let attribute):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              XCTAssertEqual(newDistinctAttribute, attribute)
 
-                    self.client.getDistinctAttribute(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let attribute):
-
-                            XCTAssertEqual(newDistinctAttribute, attribute)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
     }
 
-    func testResetDistinctAttributes() {
+    self.wait(for: [expectation], timeout: 10.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset settings for distinct attributes")
+  func testResetDistinctAttributes() {
 
-        self.client.resetDistinctAttribute(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Reset settings for distinct attributes")
+
+    self.client.resetDistinctAttribute(UID: self.uid) { result in
+
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getDistinctAttribute(UID: self.uid) { result in
 
             switch result {
-            case .success(let update):
+            case .success(let attribute):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              XCTAssertEqual(self.defaultDistinctAttribute, attribute)
 
-                    self.client.getDistinctAttribute(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let attribute):
-
-                            XCTAssertEqual(self.defaultDistinctAttribute, attribute)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    // MARK: Ranking rules
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-    func testGetRankingRules() {
+  // MARK: Ranking rules
 
-        let expectation = XCTestExpectation(description: "Get current ranking rules")
+  func testGetRankingRules() {
 
-        self.client.getRankingRules(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Get current ranking rules")
+
+    self.client.getRankingRules(UID: self.uid) { result in
+      switch result {
+      case .success(let rankingRules):
+
+        XCTAssertEqual(self.defaultRankingRules, rankingRules)
+
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateRankingRules() {
+
+    let expectation = XCTestExpectation(description: "Update settings for ranking rules")
+
+    let newRankingRules: [String] = [
+      "words",
+      "typo",
+      "proximity"
+    ]
+
+    self.client.updateRankingRules(UID: self.uid, newRankingRules) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getRankingRules(UID: self.uid) { result in
+
             switch result {
             case .success(let rankingRules):
 
-                XCTAssertEqual(self.defaultRankingRules, rankingRules)
+              XCTAssertEqual(newRankingRules, rankingRules)
 
-                expectation.fulfill()
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testUpdateRankingRules() {
-
-        let expectation = XCTestExpectation(description: "Update settings for ranking rules")
-
-        let newRankingRules: [String] = [
-            "words",
-            "typo",
-            "proximity"
-        ]
-
-        self.client.updateRankingRules(UID: self.uid, newRankingRules) { result in
-            switch result {
-            case .success(let update):
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getRankingRules(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let rankingRules):
-
-                            XCTAssertEqual(newRankingRules, rankingRules)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 2.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testResetRankingRules() {
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset settings for ranking rules")
+  func testResetRankingRules() {
 
-        self.client.resetRankingRules(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Reset settings for ranking rules")
+
+    self.client.resetRankingRules(UID: self.uid) { result in
+
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getRankingRules(UID: self.uid) { result in
 
             switch result {
-            case .success(let update):
+            case .success(let rankingRules):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getRankingRules(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let rankingRules):
-
-                            XCTAssertEqual(self.defaultRankingRules, rankingRules)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              XCTAssertEqual(self.defaultRankingRules, rankingRules)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    // MARK: Searchable attributes
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-    func testGetSearchableAttributes() {
+  // MARK: Searchable attributes
 
-        let expectation = XCTestExpectation(description: "Get current searchable attributes")
+  func testGetSearchableAttributes() {
 
-        self.client.getSearchableAttributes(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Get current searchable attributes")
+
+    self.client.getSearchableAttributes(UID: self.uid) { result in
+      switch result {
+      case .success(let searchableAttributes):
+
+        XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
+
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateSearchableAttributes() {
+
+    let expectation = XCTestExpectation(description: "Update settings for searchable attributes")
+
+    let newSearchableAttributes: [String] = [
+      "id",
+      "title"
+    ]
+
+    self.client.updateSearchableAttributes(UID: self.uid, newSearchableAttributes) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getSearchableAttributes(UID: self.uid) { result in
+
             switch result {
             case .success(let searchableAttributes):
 
-                XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
+              XCTAssertEqual(newSearchableAttributes, searchableAttributes)
 
-                expectation.fulfill()
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testUpdateSearchableAttributes() {
-
-        let expectation = XCTestExpectation(description: "Update settings for searchable attributes")
-
-        let newSearchableAttributes: [String] = [
-            "id",
-            "title"
-        ]
-
-        self.client.updateSearchableAttributes(UID: self.uid, newSearchableAttributes) { result in
-            switch result {
-            case .success(let update):
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getSearchableAttributes(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let searchableAttributes):
-
-                            XCTAssertEqual(newSearchableAttributes, searchableAttributes)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 2.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
     }
 
-    func testResetSearchableAttributes() {
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset settings for searchable attributes")
+  func testResetSearchableAttributes() {
 
-        self.client.resetSearchableAttributes(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Reset settings for searchable attributes")
+
+    self.client.resetSearchableAttributes(UID: self.uid) { result in
+
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getSearchableAttributes(UID: self.uid) { result in
 
             switch result {
-            case .success(let update):
+            case .success(let searchableAttributes):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getSearchableAttributes(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let searchableAttributes):
-
-                            XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              XCTAssertEqual(self.defaultSearchableAttributes, searchableAttributes)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    // // MARK: Stop words
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-    func testGetStopWords() {
+  // // MARK: Stop words
 
-        let expectation = XCTestExpectation(description: "Get current stop words")
+  func testGetStopWords() {
 
-        self.client.getStopWords(UID: self.uid) { result in
+    let expectation = XCTestExpectation(description: "Get current stop words")
+
+    self.client.getStopWords(UID: self.uid) { result in
+      switch result {
+
+      case .success(let stopWords):
+        XCTAssertEqual(self.defaultStopWords, stopWords)
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateStopWords() {
+
+    let expectation = XCTestExpectation(description: "Update stop words")
+
+    let newStopWords: [String] = ["the"]
+
+    self.client.updateStopWords(UID: self.uid, newStopWords) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getStopWords(UID: self.uid) { result in
+
             switch result {
+            case .success(let finalStopWords):
 
+              XCTAssertEqual(newStopWords, finalStopWords)
+
+              expectation.fulfill()
+
+            case .failure(let error):
+              print(error)
+              XCTFail()
+            }
+
+          }
+
+        }
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
+    }
+
+    self.wait(for: [expectation], timeout: 10.0)
+  }
+
+  func testResetStopWords() {
+
+    let expectation = XCTestExpectation(description: "Reset stop words")
+
+    self.client.resetStopWords(UID: self.uid) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getStopWords(UID: self.uid) { result in
+
+            switch result {
             case .success(let stopWords):
-                XCTAssertEqual(self.defaultStopWords, stopWords)
-                expectation.fulfill()
+              XCTAssertEqual(self.defaultStopWords, stopWords)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testUpdateStopWords() {
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Update stop words")
+  // MARK: Synonyms
 
-        let newStopWords: [String] = ["the"]
+  func testGetSynonyms() {
 
-        self.client.updateStopWords(UID: self.uid, newStopWords) { result in
+    let expectation = XCTestExpectation(description: "Get current synonyms")
+
+    self.client.getSynonyms(UID: self.uid) { result in
+      switch result {
+      case .success(let synonyms):
+
+        XCTAssertEqual(self.defaultSynonyms, synonyms)
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateSynonyms() {
+
+    let expectation = XCTestExpectation(description: "Update synonyms")
+
+    let newSynonyms: [String: [String]] = [
+      "wolverine": ["xmen", "logan"],
+      "logan": ["wolverine", "xmen"],
+      "wow": ["world of warcraft"],
+      "rct": ["rollercoaster tycoon"]
+    ]
+
+    self.client.updateSynonyms(UID: self.uid, newSynonyms) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getSynonyms(UID: self.uid) { result in
+
             switch result {
-            case .success(let update):
+            case .success(let updatedSynonyms):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              let rhs = Array(updatedSynonyms.keys).sorted(by: <)
+              XCTAssertEqual(Array(newSynonyms.keys).sorted(by: <), rhs)
 
-                    self.client.getStopWords(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let finalStopWords):
-
-                            XCTAssertEqual(newStopWords, finalStopWords)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testResetStopWords() {
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset stop words")
+  func testResetSynonyms() {
 
-        self.client.resetStopWords(UID: self.uid) { result in
-            switch result {
-            case .success(let update):
+    let expectation = XCTestExpectation(description: "Reset synonyms")
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+    self.client.resetSynonyms(UID: self.uid) { result in
+      switch result {
+      case .success(let update):
 
-                    self.client.getStopWords(UID: self.uid) { result in
+        waitForPendingUpdate(self.client, self.uid, update) {
 
-                        switch result {
-                        case .success(let stopWords):
-                            XCTAssertEqual(self.defaultStopWords, stopWords)
-                            expectation.fulfill()
+          self.client.getSynonyms(UID: self.uid) { result in
 
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Synonyms
-
-    func testGetSynonyms() {
-
-        let expectation = XCTestExpectation(description: "Get current synonyms")
-
-        self.client.getSynonyms(UID: self.uid) { result in
             switch result {
             case .success(let synonyms):
 
-                XCTAssertEqual(self.defaultSynonyms, synonyms)
-                expectation.fulfill()
+              XCTAssertEqual(self.defaultSynonyms, synonyms)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 1.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testUpdateSynonyms() {
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Update synonyms")
+  // MARK: Global Settings
 
-        let newSynonyms: [String: [String]] = [
-            "wolverine": ["xmen", "logan"],
-            "logan": ["wolverine", "xmen"],
-            "wow": ["world of warcraft"],
-            "rct": ["rollercoaster tycoon"]
-        ]
+  func testGetSettings() {
 
-        self.client.updateSynonyms(UID: self.uid, newSynonyms) { result in
+    let expectation = XCTestExpectation(description: "Get current settings")
+
+    self.client.getSetting(UID: self.uid) { result in
+      switch result {
+      case .success(let settings):
+        XCTAssertEqual(self.defaultGlobalSettings, settings)
+        expectation.fulfill()
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testUpdateSettings() {
+
+    let expectation = XCTestExpectation(description: "Update settings")
+
+    let newSettings: Setting = Setting(
+      rankingRules: ["words", "typo", "proximity", "attribute", "wordsPosition", "exactness"],
+      searchableAttributes: ["id", "title"],
+      displayedAttributes: ["*"],
+      stopWords: ["the", "a"],
+      synonyms: [:],
+      distinctAttribute: nil,
+      attributesForFaceting: ["title"])
+
+    self.client.updateSetting(UID: self.uid, newSettings) { result in
+      switch result {
+      case .success(let update):
+
+        waitForPendingUpdate(self.client, self.uid, update) {
+
+          self.client.getSetting(UID: self.uid) { result in
+
             switch result {
-            case .success(let update):
+            case .success(let finalSetting):
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+              XCTAssertEqual(newSettings.rankingRules.sorted(), finalSetting.rankingRules.sorted())
+              XCTAssertEqual(newSettings.searchableAttributes.sorted(), finalSetting.searchableAttributes.sorted())
+              XCTAssertEqual(newSettings.displayedAttributes.sorted(), finalSetting.displayedAttributes.sorted())
+              XCTAssertEqual(newSettings.stopWords.sorted(), finalSetting.stopWords.sorted())
+              XCTAssertEqual(newSettings.attributesForFaceting, finalSetting.attributesForFaceting)
+              XCTAssertEqual(Array(newSettings.synonyms.keys).sorted(by: <), Array(finalSetting.synonyms.keys).sorted(by: <))
 
-                    self.client.getSynonyms(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let updatedSynonyms):
-
-                            let rhs = Array(updatedSynonyms.keys).sorted(by: <)
-                            XCTAssertEqual(Array(newSynonyms.keys).sorted(by: <), rhs)
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
+
+          }
+
         }
 
-        self.wait(for: [expectation], timeout: 2.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+
     }
 
-    func testResetSynonyms() {
+    self.wait(for: [expectation], timeout: 10.0)
+  }
 
-        let expectation = XCTestExpectation(description: "Reset synonyms")
+  func testResetSettings() {
 
-        self.client.resetSynonyms(UID: self.uid) { result in
-            switch result {
-            case .success(let update):
+    let expectation = XCTestExpectation(description: "Reset settings")
 
-                waitForPendingUpdate(self.client, self.uid, update) {
+    self.client.resetSetting(UID: self.uid) { result in
+      switch result {
+      case .success(let update):
 
-                    self.client.getSynonyms(UID: self.uid) { result in
+        waitForPendingUpdate(self.client, self.uid, update) {
 
-                        switch result {
-                        case .success(let synonyms):
+          self.client.getSetting(UID: self.uid) { result in
 
-                            XCTAssertEqual(self.defaultSynonyms, synonyms)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    // MARK: Global Settings
-
-    func testGetSettings() {
-
-        let expectation = XCTestExpectation(description: "Get current settings")
-
-        self.client.getSetting(UID: self.uid) { result in
             switch result {
             case .success(let settings):
-                XCTAssertEqual(self.defaultGlobalSettings, settings)
-                expectation.fulfill()
+
+              XCTAssertEqual(self.defaultGlobalSettings, settings)
+              expectation.fulfill()
 
             case .failure(let error):
-                print(error)
-                XCTFail()
+              print(error)
+              XCTFail()
             }
-        }
 
-        self.wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testUpdateSettings() {
-
-        let expectation = XCTestExpectation(description: "Update settings")
-
-        let newSettings: Setting = Setting(
-            rankingRules: ["words", "typo", "proximity", "attribute", "wordsPosition", "exactness"],
-            searchableAttributes: ["id", "title"],
-            displayedAttributes: ["*"],
-            stopWords: ["the", "a"],
-            synonyms: [:],
-            distinctAttribute: nil,
-            attributesForFaceting: ["title"])
-
-        self.client.updateSetting(UID: self.uid, newSettings) { result in
-            switch result {
-            case .success(let update):
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getSetting(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let finalSetting):
-
-                            XCTAssertEqual(newSettings.rankingRules.sorted(), finalSetting.rankingRules.sorted())
-                            XCTAssertEqual(newSettings.searchableAttributes.sorted(), finalSetting.searchableAttributes.sorted())
-                            XCTAssertEqual(newSettings.displayedAttributes.sorted(), finalSetting.displayedAttributes.sorted())
-                            XCTAssertEqual(newSettings.stopWords.sorted(), finalSetting.stopWords.sorted())
-                            XCTAssertEqual(newSettings.attributesForFaceting, finalSetting.attributesForFaceting)
-                            XCTAssertEqual(Array(newSettings.synonyms.keys).sorted(by: <), Array(finalSetting.synonyms.keys).sorted(by: <))
-
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
+          }
 
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
     }
 
-    func testResetSettings() {
-
-        let expectation = XCTestExpectation(description: "Reset settings")
-
-        self.client.resetSetting(UID: self.uid) { result in
-            switch result {
-            case .success(let update):
-
-                waitForPendingUpdate(self.client, self.uid, update) {
-
-                    self.client.getSetting(UID: self.uid) { result in
-
-                        switch result {
-                        case .success(let settings):
-
-                            XCTAssertEqual(self.defaultGlobalSettings, settings)
-                            expectation.fulfill()
-
-                        case .failure(let error):
-                            print(error)
-                            XCTFail()
-                        }
-
-                    }
-
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-    }
+    self.wait(for: [expectation], timeout: 1.0)
+  }
 
 }
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -2,125 +2,129 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 private struct Movie: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let comment: String?
+  let id: Int
+  let title: String
+  let comment: String?
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case comment
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+  }
 
-    init(id: Int, title: String, comment: String? = nil) {
-        self.id = id
-        self.title = title
-        self.comment = comment
-    }
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+  }
 
 }
 
 class UpdatesTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let uid: String = "books_test"
+  private var client: MeiliSearch!
+  private let uid: String = "books_test"
 
-    // MARK: Setup
+  // MARK: Setup
 
-    override func setUp() {
-        super.setUp()
+  override func setUp() {
+    super.setUp()
 
-        if client == nil {
-            client = try! MeiliSearch("http://localhost:7700", "masterKey")
-        }
-
-        pool(client)
-
-        let expectation = XCTestExpectation(description: "Create index if it does not exist")
-
-        self.client.deleteIndex(UID: uid) { _ in
-            self.client.getOrCreateIndex(UID: self.uid) { result in
-                switch result {
-                case .success:
-                    expectation.fulfill()
-                case .failure(let error):
-                    print(error)
-                    XCTFail()
-                }
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
+    if client == nil {
+      client = try! MeiliSearch("http://localhost:7700", "masterKey")
     }
 
-    func testGetUpdateStatus() {
+    pool(client)
 
-        let expectation = XCTestExpectation(description: "Get update status for transaction")
+    let expectation = XCTestExpectation(description: "Create index if it does not exist")
 
-        let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
-        let documents: Data = try! JSONEncoder().encode([movie])
+    self.client.deleteIndex(UID: uid) { _ in
+      self.client.getOrCreateIndex(UID: self.uid) { result in
+        switch result {
+        case .success:
+          expectation.fulfill()
+        case .failure(let error):
+          print(error)
+          XCTFail()
+        }
+      }
+    }
 
-        self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { result in
+    self.wait(for: [expectation], timeout: 10.0)
+  }
 
-            switch result {
-            case .success(let update):
+  func testGetUpdateStatus() {
 
-                self.client.getUpdate(UID: self.uid, update) { (result: Result<Update.Result, Swift.Error>)  in
+    let expectation = XCTestExpectation(description: "Get update status for transaction")
 
-                    switch result {
-                    case .success(let update):
-                        XCTAssertEqual("DocumentsAddition", update.type.name)
-                        XCTAssertTrue(update.type.number! >= 0)
-                    case .failure(let error):
-                        print(error)
-                        XCTFail()
-                    }
-                    expectation.fulfill()
+    let movie: Movie = Movie(id: 10, title: "test", comment: "test movie")
+    let documents: Data = try! JSONEncoder().encode([movie])
 
-                }
+    self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { result in
 
-            case .failure:
-                XCTFail("Failed to update movie index")
-            }
+      switch result {
+      case .success(let update):
+
+        self.client.getUpdate(UID: self.uid, update) { (result: Result<Update.Result, Swift.Error>)  in
+
+          switch result {
+          case .success(let update):
+            XCTAssertEqual("DocumentsAddition", update.type.name)
+            XCTAssertTrue(update.type.number! >= 0)
+          case .failure(let error):
+            print(error)
+            XCTFail()
+          }
+          expectation.fulfill()
+
         }
 
-        self.wait(for: [expectation], timeout: 10.0)
+      case .failure:
+        XCTFail("Failed to update movie index")
+      }
+    }
+
+    self.wait(for: [expectation], timeout: 10.0)
+
+  }
+
+  func testGetAllUpdatesStatus() {
+
+    let expectation = XCTestExpectation(description: "Get update status for all transaction")
+
+    let jsonEncoder = JSONEncoder()
+
+    for index in 0...10 {
+      let movie: Movie = Movie(id: index, title: "test\(index)", comment: "test movie\(index)")
+      let documents: Data = try! jsonEncoder.encode([movie])
+      self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { _ in }
+    }
+
+    self.client.getAllUpdates(UID: self.uid) { (result: Result<[Update.Result], Swift.Error>)  in
+
+      switch result {
+      case .success(let updates):
+        updates.forEach { (update: Update.Result) in
+          XCTAssertEqual("DocumentsAddition", update.type.name)
+          XCTAssertTrue(update.type.number! >= 0)
+        }
+
+      case .failure(let error):
+        print(error)
+        XCTFail()
+      }
+      expectation.fulfill()
 
     }
 
-    func testGetAllUpdatesStatus() {
+    self.wait(for: [expectation], timeout: 10.0)
 
-        let expectation = XCTestExpectation(description: "Get update status for all transaction")
-
-        let jsonEncoder = JSONEncoder()
-
-        for i in 0...10 {
-            let movie: Movie = Movie(id: i, title: "test\(i)", comment: "test movie\(i)")
-            let documents: Data = try! jsonEncoder.encode([movie])
-            self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { _ in }
-        }
-
-        self.client.getAllUpdates(UID: self.uid) { (result: Result<[Update.Result], Swift.Error>)  in
-
-            switch result {
-            case .success(let updates):
-                updates.forEach { (update: Update.Result) in
-                  XCTAssertEqual("DocumentsAddition", update.type.name)
-                  XCTAssertTrue(update.type.number! >= 0)
-                }
-
-            case .failure(let error):
-                print(error)
-                XCTFail()
-            }
-            expectation.fulfill()
-
-        }
-
-        self.wait(for: [expectation], timeout: 10.0)
-
-    }
+  }
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchIntegrationTests/XCTestManifests.swift
+++ b/Tests/MeiliSearchIntegrationTests/XCTestManifests.swift
@@ -6,19 +6,19 @@
  
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import XCTest
 
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
-    [
-        testCase(IndexesTests.allTests),
-        testCase(DocumentsTests.allTests),
-        testCase(SearchTests.allTests),
-        testCase(SettingsTests.allTests),
-        testCase(UpdatesTests.allTests),
-        testCase(DumpsTests.allTests)
-    ]
+  [
+    testCase(IndexesTests.allTests),
+    testCase(DocumentsTests.allTests),
+    testCase(SearchTests.allTests),
+    testCase(SettingsTests.allTests),
+    testCase(UpdatesTests.allTests),
+    testCase(DumpsTests.allTests)
+  ]
 }
 #endif

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -1,6 +1,7 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_cast
 class ClientTests: XCTestCase {
 
   private let session = MockURLSession()
@@ -21,9 +22,10 @@ class ClientTests: XCTestCase {
   }
 
   static var allTests = [
-      ("testValidHostURL", testValidHostURL),
-      ("testWrongHostURL", testWrongHostURL),
-      ("testNotValidHostURL", testNotValidHostURL)
+    ("testValidHostURL", testValidHostURL),
+    ("testWrongHostURL", testWrongHostURL),
+    ("testNotValidHostURL", testNotValidHostURL)
   ]
 
 }
+// swiftlint:enable force_cast

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -2,97 +2,101 @@
 import XCTest
 import Foundation
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_cast
+// swiftlint:disable force_try
+// swiftlint:disable line_length
 private struct Movie: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let overview: String
-    let releaseDate: Date
+  let id: Int
+  let title: String
+  let overview: String
+  let releaseDate: Date
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case overview
-        case releaseDate = "release_date"
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case overview
+    case releaseDate = "release_date"
+  }
 
 }
 
 class DocumentsTests: XCTestCase {
 
-    private var client: MeiliSearch!
+  private var client: MeiliSearch!
 
-    private let session = MockURLSession()
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testAddDocuments() {
+  func testAddDocuments() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let jsonString = """
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString, code: 202)
+    session.pushData(jsonString, code: 202)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let movie = Movie(
-            id: 287947,
-            title: "Shazam",
-            overview: "A boy is given the ability to become an adult superhero in times of need with a single magic word.",
-            releaseDate: Date(timeIntervalSince1970: TimeInterval(1553299200)))
+    let movie = Movie(
+      id: 287947,
+      title: "Shazam",
+      overview: "A boy is given the ability to become an adult superhero in times of need with a single magic word.",
+      releaseDate: Date(timeIntervalSince1970: TimeInterval(1553299200)))
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
-        self.client.addDocuments(
-            UID: uid,
-            documents: [movie],
-            primaryKey: "") { result in
+    self.client.addDocuments(
+      UID: uid,
+      documents: [movie],
+      primaryKey: "") { result in
 
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or replace Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to add or replace Movies document")
+      }
 
     }
 
-    func testAddDataDocuments() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testAddDataDocuments() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString, code: 202)
+    session.pushData(jsonString, code: 202)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let documentJsonString = """
+    let documentJsonString = """
         [{
             "id": 287947,
             "title": "Shazam",
@@ -102,86 +106,86 @@ class DocumentsTests: XCTestCase {
         }]
         """
 
-        let primaryKey: String = ""
+    let primaryKey: String = ""
 
-        let documents: Data = documentJsonString.data(using: .utf8)!
+    let documents: Data = documentJsonString.data(using: .utf8)!
 
-        let expectation = XCTestExpectation(description: "Add or replace Movies document")
+    let expectation = XCTestExpectation(description: "Add or replace Movies document")
 
-        self.client.addDocuments(
-            UID: uid,
-            documents: documents,
-            primaryKey: primaryKey) { result in
+    self.client.addDocuments(
+      UID: uid,
+      documents: documents,
+      primaryKey: primaryKey) { result in
 
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or replace Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to add or replace Movies document")
+      }
 
     }
 
-    func testUpdateDocuments() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateDocuments() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString, code: 202)
+    session.pushData(jsonString, code: 202)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let documentJsonString = """
+    let documentJsonString = """
         [{
             "id": 287947,
             "title": "Shazam ⚡️"
         }]
         """
 
-        let primaryKey: String = "movieskud"
+    let primaryKey: String = "movieskud"
 
-        let documents: Data = documentJsonString.data(using: .utf8)!
+    let documents: Data = documentJsonString.data(using: .utf8)!
 
-        let expectation = XCTestExpectation(description: "Add or update Movies document")
+    let expectation = XCTestExpectation(description: "Add or update Movies document")
 
-        self.client.updateDocuments(
-            UID: uid,
-            documents: documents,
-            primaryKey: primaryKey) { result in
+    self.client.updateDocuments(
+      UID: uid,
+      documents: documents,
+      primaryKey: primaryKey) { result in
 
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to add or update Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to add or update Movies document")
+      }
 
     }
 
-    func testGetDocument() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testGetDocument() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "id": 25684,
             "title": "American Ninja 5",
@@ -191,41 +195,41 @@ class DocumentsTests: XCTestCase {
         }
         """
 
-        session.pushData(jsonString, code: 200)
+    session.pushData(jsonString, code: 200)
 
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
+    let decoder: JSONDecoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+    let data = jsonString.data(using: .utf8)!
+    let stubMovie: Movie = try! decoder.decode(Movie.self, from: data)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
-        let identifier: String = "25684"
+    let uid: String = "Movies"
+    let identifier: String = "25684"
 
-        let expectation = XCTestExpectation(description: "Get Movies document")
+    let expectation = XCTestExpectation(description: "Get Movies document")
 
-      self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
+    self.client.getDocument(UID: uid, identifier: identifier) { (result: Result<Movie, Swift.Error>) in
 
-            switch result {
-            case .success(let movie):
-                XCTAssertEqual(stubMovie, movie)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies document")
-            }
-
+      switch result {
+      case .success(let movie):
+        XCTAssertEqual(stubMovie, movie)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get Movies document")
       }
-
-        self.wait(for: [expectation], timeout: 1.0)
 
     }
 
-    func testGetDocuments() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testGetDocuments() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         [{
             "id": 25684,
             "release_date": "2020-04-04T19:59:49.259572Z",
@@ -241,175 +245,179 @@ class DocumentsTests: XCTestCase {
         }]
         """
 
-        session.pushData(jsonString, code: 200)
+    session.pushData(jsonString, code: 200)
 
-        let decoder: JSONDecoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
-        let data = jsonString.data(using: .utf8)!
-        let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
+    let decoder: JSONDecoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .formatted(Formatter.iso8601)
+    let data = jsonString.data(using: .utf8)!
+    let stubMovies: [Movie] = try! decoder.decode([Movie].self, from: data)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
-        let limit: Int = 10
+    let uid: String = "Movies"
+    let limit: Int = 10
 
-        let expectation = XCTestExpectation(description: "Get Movies documents")
+    let expectation = XCTestExpectation(description: "Get Movies documents")
 
-        self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
+    self.client.getDocuments(UID: uid, limit: limit) { (result: Result<[Movie], Swift.Error>) in
 
-            switch result {
-            case .success(let movies):
-                XCTAssertEqual(stubMovies, movies)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteDocument() {
-
-        // Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let identifier: String = "25684"
-
-        let expectation = XCTestExpectation(description: "Delete Movies document")
-
-        self.client.deleteDocument(UID: uid, identifier: identifier) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete Movies document")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteAllDocuments() {
-
-        // Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-        self.client.deleteAllDocuments(UID: uid) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testDeleteBatchDocuments() {
-
-        // Prepare the mock server
-
-        let jsonString = """
-        {"updateId":0}
-        """
-
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
-
-        session.pushData(jsonString, code: 202)
-
-        // Start the test with the mocked server
-
-        let uid = "Movies"
-        let documentsUID: [Int] = [23488, 153738, 437035, 363869]
-        let expectation = XCTestExpectation(description: "Delete all Movies documents")
-
-      self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
-
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete all Movies documents")
-            }
-
+      switch result {
+      case .success(let movies):
+        XCTAssertEqual(stubMovies, movies)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get Movies documents")
       }
 
-        self.wait(for: [expectation], timeout: 1.0)
+    }
+
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  func testDeleteDocument() {
+
+    // Prepare the mock server
+
+    let jsonString = """
+        {"updateId":0}
+        """
+
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+
+    session.pushData(jsonString, code: 202)
+
+    // Start the test with the mocked server
+
+    let uid = "Movies"
+    let identifier: String = "25684"
+
+    let expectation = XCTestExpectation(description: "Delete Movies document")
+
+    self.client.deleteDocument(UID: uid, identifier: identifier) { result in
+
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to delete Movies document")
+      }
 
     }
 
-    private func convertToDictionary(_ string: String) -> [String: Any] {
-        if let data: Data = string.data(using: .utf8) {
-            do {
-                return try JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
-            } catch {
-                fatalError(error.localizedDescription)
-            }
-        }
-        fatalError()
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  func testDeleteAllDocuments() {
+
+    // Prepare the mock server
+
+    let jsonString = """
+        {"updateId":0}
+        """
+
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+
+    session.pushData(jsonString, code: 202)
+
+    // Start the test with the mocked server
+
+    let uid = "Movies"
+    let expectation = XCTestExpectation(description: "Delete all Movies documents")
+
+    self.client.deleteAllDocuments(UID: uid) { result in
+
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to delete all Movies documents")
+      }
+
     }
 
-    private func convertToArrayDictionary(_ string: String) -> [[String: Any]] {
-        if let data: Data = string.data(using: .utf8) {
-            do {
-                return try JSONSerialization.jsonObject(with: data, options: []) as! [[String: Any]]
-            } catch {
-                fatalError(error.localizedDescription)
-            }
-        }
-        fatalError()
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  func testDeleteBatchDocuments() {
+
+    // Prepare the mock server
+
+    let jsonString = """
+        {"updateId":0}
+        """
+
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+
+    session.pushData(jsonString, code: 202)
+
+    // Start the test with the mocked server
+
+    let uid = "Movies"
+    let documentsUID: [Int] = [23488, 153738, 437035, 363869]
+    let expectation = XCTestExpectation(description: "Delete all Movies documents")
+
+    self.client.deleteBatchDocuments(UID: uid, documentsUID: documentsUID) { result in
+
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to delete all Movies documents")
+      }
+
     }
 
-    static var allTests = [
-        ("testAddDocuments", testAddDocuments),
-        ("testAddDataDocuments", testAddDataDocuments),
-        ("testUpdateDocuments", testUpdateDocuments),
-        ("testGetDocument", testGetDocument),
-        ("testGetDocuments", testGetDocuments),
-        ("testDeleteDocument", testDeleteDocument),
-        ("testDeleteAllDocuments", testDeleteAllDocuments),
-        ("testDeleteBatchDocuments", testDeleteBatchDocuments)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  private func convertToDictionary(_ string: String) -> [String: Any] {
+    if let data: Data = string.data(using: .utf8) {
+      do {
+        return try JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+      } catch {
+        fatalError(error.localizedDescription)
+      }
+    }
+    fatalError()
+  }
+
+  private func convertToArrayDictionary(_ string: String) -> [[String: Any]] {
+    if let data: Data = string.data(using: .utf8) {
+      do {
+        return try JSONSerialization.jsonObject(with: data, options: []) as! [[String: Any]]
+      } catch {
+        fatalError(error.localizedDescription)
+      }
+    }
+    fatalError()
+  }
+
+  static var allTests = [
+    ("testAddDocuments", testAddDocuments),
+    ("testAddDataDocuments", testAddDataDocuments),
+    ("testUpdateDocuments", testUpdateDocuments),
+    ("testGetDocument", testGetDocument),
+    ("testGetDocuments", testGetDocuments),
+    ("testDeleteDocument", testDeleteDocument),
+    ("testDeleteAllDocuments", testDeleteAllDocuments),
+    ("testDeleteBatchDocuments", testDeleteBatchDocuments)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_cast
+// swiftlint:enable force_try
+// swiftlint:enable line_length

--- a/Tests/MeiliSearchUnitTests/DumpsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DumpsTests.swift
@@ -1,91 +1,95 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class DumpsTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testCreateDump() {
+  func testCreateDump() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let json = """
+    let json = """
         {
           "uid": "20200929-114144097",
           "status": "in_progress"
         }
         """
 
-        let data = json.data(using: .utf8)!
+    let data = json.data(using: .utf8)!
 
-        let stubDump: Dump = try! Constants.customJSONDecoder.decode(Dump.self, from: data)
+    let stubDump: Dump = try! Constants.customJSONDecoder.decode(Dump.self, from: data)
 
-        session.pushData(json)
+    session.pushData(json)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Create dump")
+    let expectation = XCTestExpectation(description: "Create dump")
 
-        self.client.createDump { result in
-            switch result {
-            case .success(let dump):
-                XCTAssertEqual(stubDump, dump)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to create dump")
-            }
-        }
+    self.client.createDump { result in
+      switch result {
+      case .success(let dump):
+        XCTAssertEqual(stubDump, dump)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to create dump")
+      }
+    }
 
-        self.wait(for: [expectation], timeout: 1.0)
+    self.wait(for: [expectation], timeout: 1.0)
 
   }
 
-    func testGetDumpStatus() {
+  func testGetDumpStatus() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let json = """
+    let json = """
         {
           "uid": "20200929-114144097",
           "status": "in_progress"
         }
         """
 
-        let data = json.data(using: .utf8)!
+    let data = json.data(using: .utf8)!
 
-        let stubDump: Dump = try! Constants.customJSONDecoder.decode(Dump.self, from: data)
+    let stubDump: Dump = try! Constants.customJSONDecoder.decode(Dump.self, from: data)
 
-        session.pushData(json)
+    session.pushData(json)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "20200929-114144097"
+    let UID: String = "20200929-114144097"
 
-        let expectation = XCTestExpectation(description: "Get the dump status")
+    let expectation = XCTestExpectation(description: "Get the dump status")
 
-        self.client.getDumpStatus(UID: UID) { result in
-            switch result {
-            case .success(let dump):
-                XCTAssertEqual(stubDump, dump)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get the dump status")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getDumpStatus(UID: UID) { result in
+      switch result {
+      case .success(let dump):
+        XCTAssertEqual(stubDump, dump)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get the dump status")
+      }
     }
 
-    static var allTests = [
-        ("testGetDumpStatus", testGetDumpStatus),
-        ("testGetSetting", testGetDumpStatus)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testGetDumpStatus", testGetDumpStatus),
+    ("testGetSetting", testGetDumpStatus)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/IndexesTests.swift
+++ b/Tests/MeiliSearchUnitTests/IndexesTests.swift
@@ -1,21 +1,23 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class IndexesTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testCreateIndex() {
+  func testCreateIndex() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let jsonString = """
+    let jsonString = """
         {
             "name":"Movies",
             "uid":"Movies",
@@ -25,37 +27,37 @@ class IndexesTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+    let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let expectation = XCTestExpectation(description: "Create Movies index")
+    let expectation = XCTestExpectation(description: "Create Movies index")
 
-        self.client.createIndex(UID: uid) { result in
-            switch result {
-            case .success(let index):
-                XCTAssertEqual(stubIndex, index)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.createIndex(UID: uid) { result in
+      switch result {
+      case .success(let index):
+        XCTAssertEqual(stubIndex, index)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get Movies index")
+      }
     }
 
-    func testGetOrCreateIndex() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testGetOrCreateIndex() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "name":"Movies",
             "uid":"Movies",
@@ -65,43 +67,43 @@ class IndexesTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+    let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let expectation = XCTestExpectation(description: "Get or create Movies index")
+    let expectation = XCTestExpectation(description: "Get or create Movies index")
 
-        self.client.getOrCreateIndex(UID: uid) { result in
-            switch result {
-            case .success(let index):
-                XCTAssertEqual(stubIndex, index)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get or create Movies index")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getOrCreateIndex(UID: uid) { result in
+      switch result {
+      case .success(let index):
+        XCTAssertEqual(stubIndex, index)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get or create Movies index")
+      }
     }
 
-    func testGetOrCreateIndexAlreadyExists() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let createJsonString = """
+  func testGetOrCreateIndexAlreadyExists() {
+
+    // Prepare the mock server
+
+    let createJsonString = """
         {"message":"Impossible to create index; index already exists","errorType":"invalid_request_error","errorCode":"index_already_exists"}
         """
 
-        session.pushError(createJsonString, nil, code: 400)
+    session.pushError(createJsonString, nil, code: 400)
 
-        let getJsonString = """
+    let getJsonString = """
         {
             "name":"Movies",
             "uid":"Movies",
@@ -111,37 +113,37 @@ class IndexesTests: XCTestCase {
         }
         """
 
-        let jsonData = getJsonString.data(using: .utf8)!
+    let jsonData = getJsonString.data(using: .utf8)!
 
-        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+    let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
-        session.pushData(getJsonString)
+    session.pushData(getJsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let expectation = XCTestExpectation(description: "Get or create Movies index")
+    let expectation = XCTestExpectation(description: "Get or create Movies index")
 
-        self.client.getOrCreateIndex(UID: uid) { result in
-            switch result {
-            case .success(let index):
-                XCTAssertEqual(stubIndex, index)
-                expectation.fulfill()
-            case .failure(let error):
-                XCTFail("Failed to get or create Movies index, error: \(error)")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getOrCreateIndex(UID: uid) { result in
+      switch result {
+      case .success(let index):
+        XCTAssertEqual(stubIndex, index)
+        expectation.fulfill()
+      case .failure(let error):
+        XCTFail("Failed to get or create Movies index, error: \(error)")
+      }
     }
 
-    func testGetIndex() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testGetIndex() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "name":"Movies",
             "uid":"Movies",
@@ -151,39 +153,39 @@ class IndexesTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+    let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let expectation = XCTestExpectation(description: "Load Movies index")
+    let expectation = XCTestExpectation(description: "Load Movies index")
 
-        self.client.getIndex(UID: uid) { result in
+    self.client.getIndex(UID: uid) { result in
 
-            switch result {
-            case .success(let index):
-                XCTAssertEqual(stubIndex, index)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get Movies index")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let index):
+        XCTAssertEqual(stubIndex, index)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get Movies index")
+      }
 
     }
 
-    func testGetIndexes() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testGetIndexes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         [{
             "name":"Movies",
             "uid":"Movies",
@@ -193,37 +195,37 @@ class IndexesTests: XCTestCase {
         }]
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndexes: [Index] = try! Constants.customJSONDecoder.decode([Index].self, from: jsonData)
+    let stubIndexes: [Index] = try! Constants.customJSONDecoder.decode([Index].self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Load indexes")
+    let expectation = XCTestExpectation(description: "Load indexes")
 
-        self.client.getIndexes { result in
+    self.client.getIndexes { result in
 
-            switch result {
-            case .success(let indexes):
-                XCTAssertEqual(stubIndexes, indexes)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get all Indexes")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let indexes):
+        XCTAssertEqual(stubIndexes, indexes)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get all Indexes")
+      }
 
     }
 
-    func testUpdateIndex() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateIndex() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
           "uid": "movie_review",
           "primaryKey": "movie_review_id",
@@ -232,66 +234,68 @@ class IndexesTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
+    let stubIndex: Index = try! Constants.customJSONDecoder.decode(Index.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let primaryKey: String = "movie_review_id"
+    let UID: String = "movies"
+    let primaryKey: String = "movie_review_id"
 
-        let expectation = XCTestExpectation(description: "Update Movies index")
+    let expectation = XCTestExpectation(description: "Update Movies index")
 
-        self.client.updateIndex(UID: UID, primaryKey: primaryKey) { result in
-            switch result {
-            case .success(let index):
-                XCTAssertEqual(stubIndex, index)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update Movies index")
-            }
-        }
+    self.client.updateIndex(UID: UID, primaryKey: primaryKey) { result in
+      switch result {
+      case .success(let index):
+        XCTAssertEqual(stubIndex, index)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update Movies index")
+      }
+    }
 
-        self.wait(for: [expectation], timeout: 1.0)
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  func testDeleteIndex() {
+
+    // Prepare the mock server
+
+    session.pushEmpty(code: 204)
+
+    // Start the test with the mocked server
+
+    let uid: String = "Movies"
+
+    let expectation = XCTestExpectation(description: "Delete Movies index")
+
+    self.client.deleteIndex(UID: uid) { result in
+
+      switch result {
+      case .success:
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to delete Movies index")
+      }
 
     }
 
-    func testDeleteIndex() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        session.pushEmpty(code: 204)
-
-        // Start the test with the mocked server
-
-        let uid: String = "Movies"
-
-        let expectation = XCTestExpectation(description: "Delete Movies index")
-
-        self.client.deleteIndex(UID: uid) { result in
-
-            switch result {
-            case .success:
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to delete Movies index")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    static var allTests = [
-        ("testCreateIndex", testCreateIndex),
-        ("testGetIndex", testGetIndex),
-        ("testGetIndexes", testGetIndexes),
-        ("testUpdateIndex", testUpdateIndex),
-        ("testDeleteIndex", testDeleteIndex)
-    ]
+  static var allTests = [
+    ("testCreateIndex", testCreateIndex),
+    ("testGetIndex", testGetIndex),
+    ("testGetIndexes", testGetIndexes),
+    ("testUpdateIndex", testUpdateIndex),
+    ("testDeleteIndex", testDeleteIndex)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/KeysTests.swift
+++ b/Tests/MeiliSearchUnitTests/KeysTests.swift
@@ -1,50 +1,54 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class KeysTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testKeys() {
+  func testKeys() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-      let jsonString = """
+    let jsonString = """
       {
           "private": "8dcbb482663333d0280fa9fedf0e0c16d52185cb67db494ce4cd34da32ce2092",
           "public": "3b3bf839485f90453acc6159ba18fbed673ca88523093def11a9b4f4320e44a5"
       }
       """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubKey: Key = try! decoder.decode(Key.self, from: jsonData)
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubKey: Key = try! decoder.decode(Key.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        let expectation = XCTestExpectation(description: "Get public and private key")
+    let expectation = XCTestExpectation(description: "Get public and private key")
 
-        self.client.keys { result in
-            switch result {
-            case .success(let key):
-                XCTAssertEqual(stubKey, key)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get public and private key")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+    self.client.keys { result in
+      switch result {
+      case .success(let key):
+        XCTAssertEqual(stubKey, key)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get public and private key")
+      }
     }
 
-    static var allTests = [
-        ("testKeys", testKeys)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+  }
+
+  static var allTests = [
+    ("testKeys", testKeys)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/MockURLSession.swift
+++ b/Tests/MeiliSearchUnitTests/MockURLSession.swift
@@ -1,71 +1,72 @@
 @testable import MeiliSearch
 import Foundation
 
+// swiftlint:disable force_unwrapping
 class MockURLSession: URLSessionProtocol {
 
-    private(set) var nextDataTask = MockURLSessionDataTask()
+  private(set) var nextDataTask = MockURLSessionDataTask()
 
-    private(set) var lastURL: URL?
+  private(set) var lastURL: URL?
 
-    private(set) var responses: [ResponsePayload] = []
+  private(set) var responses: [ResponsePayload] = []
 
   func successHttpURLResponse(_ request: URLRequest, _ nextCode: Int) -> URLResponse {
-        HTTPURLResponse(url: request.url!, statusCode: nextCode, httpVersion: "HTTP/1.1", headerFields: nil)!
+    HTTPURLResponse(url: request.url!, statusCode: nextCode, httpVersion: "HTTP/1.1", headerFields: nil)!
+  }
+
+  func failureHttpURLResponse(_ request: URLRequest, _ nextCode: Int) -> URLResponse {
+    HTTPURLResponse(url: request.url!, statusCode: nextCode, httpVersion: "HTTP/1.1", headerFields: nil)!
+  }
+
+  func execute(with request: URLRequest, completionHandler: @escaping DataTaskResult) -> URLSessionDataTaskProtocol {
+
+    let first: ResponsePayload = !responses.isEmpty ? responses.removeFirst() : ResponsePayload.default
+    lastURL = request.url
+
+    if first.nextType == ResponseStatus.success {
+      completionHandler(first.nextData, successHttpURLResponse(request, first.nextCode), first.nextError)
+    } else {
+      completionHandler(first.nextData, failureHttpURLResponse(request, first.nextCode), first.nextError)
     }
 
-    func failureHttpURLResponse(_ request: URLRequest, _ nextCode: Int) -> URLResponse {
-        HTTPURLResponse(url: request.url!, statusCode: nextCode, httpVersion: "HTTP/1.1", headerFields: nil)!
-    }
+    return nextDataTask
+  }
 
-    func execute(with request: URLRequest, completionHandler: @escaping DataTaskResult) -> URLSessionDataTaskProtocol {
+  func pushData(_ string: String, code: Int = 200) {
+    let payload = ResponsePayload(
+      nextType: ResponseStatus.success,
+      nextData: string.data(using: .utf8),
+      nextError: nil,
+      nextCode: code)
+    responses.append(payload)
+  }
 
-        let first: ResponsePayload = !responses.isEmpty ? responses.removeFirst() : ResponsePayload.default
-        lastURL = request.url
+  func pushEmpty(code: Int) {
+    let payload = ResponsePayload(
+      nextType: ResponseStatus.success,
+      nextData: nil,
+      nextError: nil,
+      nextCode: code)
+    responses.append(payload)
+  }
 
-        if first.nextType == ResponseStatus.success {
-            completionHandler(first.nextData, successHttpURLResponse(request, first.nextCode), first.nextError)
-        } else {
-            completionHandler(first.nextData, failureHttpURLResponse(request, first.nextCode), first.nextError)
-        }
-
-        return nextDataTask
-    }
-
-    func pushData(_ string: String, code: Int = 200) {
-        let payload = ResponsePayload(
-            nextType: ResponseStatus.success,
-            nextData: string.data(using: .utf8),
-            nextError: nil,
-            nextCode: code)
-        responses.append(payload)
-    }
-
-    func pushEmpty(code: Int) {
-        let payload = ResponsePayload(
-            nextType: ResponseStatus.success,
-            nextData: nil,
-            nextError: nil,
-            nextCode: code)
-        responses.append(payload)
-    }
-
-    func pushError(_ string: String? = nil, _ error: Error? = nil, code: Int) {
-        let payload = ResponsePayload(
-            nextType: ResponseStatus.error,
-            nextData: string?.data(using: .utf8),
-            nextError: error ?? NSError(domain: "", code: code, userInfo: nil),
-            nextCode: code)
-        responses.append(payload)
-    }
+  func pushError(_ string: String? = nil, _ error: Error? = nil, code: Int) {
+    let payload = ResponsePayload(
+      nextType: ResponseStatus.error,
+      nextData: string?.data(using: .utf8),
+      nextError: error ?? NSError(domain: "", code: code, userInfo: nil),
+      nextCode: code)
+    responses.append(payload)
+  }
 
 }
 
 class MockURLSessionDataTask: URLSessionDataTaskProtocol {
-    private (set) var resumeWasCalled = false
+  private (set) var resumeWasCalled = false
 
-    func resume() {
-        resumeWasCalled = true
-    }
+  func resume() {
+    resumeWasCalled = true
+  }
 }
 
 enum ResponseStatus {
@@ -73,10 +74,11 @@ enum ResponseStatus {
 }
 
 struct ResponsePayload {
-    let nextType: ResponseStatus
-    let nextData: Data?
-    let nextError: Error?
-    let nextCode: Int
+  let nextType: ResponseStatus
+  let nextData: Data?
+  let nextError: Error?
+  let nextCode: Int
 
   static let `default` = ResponsePayload(nextType: ResponseStatus.success, nextData: nil, nextError: nil, nextCode: 200)
 }
+// swiftlint:enable force_unwrapping

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -1,39 +1,41 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 private struct Movie: Codable, Equatable {
 
-    let id: Int
-    let title: String
-    let poster: String
-    let overview: String
-    let releaseDate: Date
+  let id: Int
+  let title: String
+  let poster: String
+  let overview: String
+  let releaseDate: Date
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case title
-        case poster
-        case overview
-        case releaseDate = "release_date"
-    }
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case poster
+    case overview
+    case releaseDate = "release_date"
+  }
 
 }
 
 class SearchTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testSearchForBotmanMovie() {
+  func testSearchForBotmanMovie() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let jsonString = """
+    let jsonString = """
         {
             "hits": [
                 {
@@ -59,41 +61,41 @@ class SearchTests: XCTestCase {
         }
         """
 
-        let data = jsonString.data(using: .utf8)!
+    let data = jsonString.data(using: .utf8)!
 
-        let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
+    let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let searchParameters = SearchParameters.query("botman")
+    let searchParameters = SearchParameters.query("botman")
 
-        let expectation = XCTestExpectation(description: "Searching for botman")
+    let expectation = XCTestExpectation(description: "Searching for botman")
 
-        typealias MeiliResult = Result<SearchResult<Movie>, Swift.Error>
+    typealias MeiliResult = Result<SearchResult<Movie>, Swift.Error>
 
-        self.client.search(UID: uid, searchParameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let searchResult):
-                XCTAssertEqual(stubSearchResult, searchResult)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search for botman")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.search(UID: uid, searchParameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let searchResult):
+        XCTAssertEqual(stubSearchResult, searchResult)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search for botman")
+      }
     }
 
-    func testSearchForBotmanMovieFacets() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testSearchForBotmanMovieFacets() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "hits": [
                 {
@@ -119,41 +121,43 @@ class SearchTests: XCTestCase {
         }
         """
 
-        let data = jsonString.data(using: .utf8)!
+    let data = jsonString.data(using: .utf8)!
 
-        let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
+    let stubSearchResult: SearchResult<Movie> = try! Constants.customJSONDecoder.decode(SearchResult<Movie>.self, from: data)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let searchParameters = SearchParameters(
-            query: "botman",
-            facetFilters: [["genre:romance"], ["genre:action"]])
+    let searchParameters = SearchParameters(
+      query: "botman",
+      facetFilters: [["genre:romance"], ["genre:action"]])
 
-        let expectation = XCTestExpectation(description: "Searching for botman")
+    let expectation = XCTestExpectation(description: "Searching for botman")
 
-        typealias MeiliResult = Result<SearchResult<Movie>, Swift.Error>
+    typealias MeiliResult = Result<SearchResult<Movie>, Swift.Error>
 
-        self.client.search(UID: uid, searchParameters) { (result: MeiliResult) in
-            switch result {
-            case .success(let searchResult):
-                XCTAssertEqual(stubSearchResult, searchResult)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to search for botman")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.search(UID: uid, searchParameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let searchResult):
+        XCTAssertEqual(stubSearchResult, searchResult)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to search for botman")
+      }
     }
 
-    static var allTests = [
-        ("testSearchForBotmanMovie", testSearchForBotmanMovie),
-        ("testSearchForBotmanMovieFacets", testSearchForBotmanMovieFacets)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testSearchForBotmanMovie", testSearchForBotmanMovie),
+    ("testSearchForBotmanMovieFacets", testSearchForBotmanMovieFacets)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -1,12 +1,15 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_cast
+// swiftlint:disable force_try
 class SettingsTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    private let json = """
+  private let json = """
     {
         "rankingRules": [
             "typo",
@@ -33,127 +36,127 @@ class SettingsTests: XCTestCase {
     }
     """
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
+
+  // MARK: Settings
+
+  func testShouldInstantiateFromEmptyData() {
+    let stubSetting: Setting = buildStubSetting(from: "{}")
+
+    XCTAssertTrue(stubSetting.rankingRules.isEmpty)
+    XCTAssertEqual(stubSetting.searchableAttributes, ["*"])
+    XCTAssertEqual(stubSetting.displayedAttributes, ["*"])
+    XCTAssertTrue(stubSetting.stopWords.isEmpty)
+    XCTAssertTrue(stubSetting.synonyms.isEmpty)
+  }
+
+  func testGetSetting() {
+
+    // Prepare the mock server
+
+    let stubSetting: Setting = buildStubSetting(from: json)
+
+    session.pushData(json)
+
+    // Start the test with the mocked server
+
+    let UID: String = "movies"
+
+    let expectation = XCTestExpectation(description: "Get settings")
+
+    self.client.getSetting(UID: UID) { result in
+      switch result {
+      case .success(let setting):
+        XCTAssertEqual(stubSetting, setting)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get settings")
+      }
     }
 
-    // MARK: Settings
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testShouldInstantiateFromEmptyData() {
-        let stubSetting: Setting = buildStubSetting(from: "{}")
+  }
 
-        XCTAssertTrue(stubSetting.rankingRules.isEmpty)
-        XCTAssertEqual(stubSetting.searchableAttributes, ["*"])
-        XCTAssertEqual(stubSetting.displayedAttributes, ["*"])
-        XCTAssertTrue(stubSetting.stopWords.isEmpty)
-        XCTAssertTrue(stubSetting.synonyms.isEmpty)
-    }
+  func testUpdateSetting() {
 
-    func testGetSetting() {
+    // Prepare the mock server
 
-        // Prepare the mock server
-
-        let stubSetting: Setting = buildStubSetting(from: json)
-
-        session.pushData(json)
-
-        // Start the test with the mocked server
-
-        let UID: String = "movies"
-
-        let expectation = XCTestExpectation(description: "Get settings")
-
-        self.client.getSetting(UID: UID) { result in
-            switch result {
-            case .success(let setting):
-                XCTAssertEqual(stubSetting, setting)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get settings")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
-    }
-
-    func testUpdateSetting() {
-
-        // Prepare the mock server
-
-        let jsonString = """
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
+    let decoder: JSONDecoder = JSONDecoder()
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let setting: Setting = buildStubSetting(from: json)
+    let UID: String = "movies"
+    let setting: Setting = buildStubSetting(from: json)
 
-        let expectation = XCTestExpectation(description: "Update settings")
+    let expectation = XCTestExpectation(description: "Update settings")
 
-        self.client.updateSetting(UID: UID, setting) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update settings")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateSetting(UID: UID, setting) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update settings")
+      }
     }
 
-    func testResetSetting() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetSetting() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let data: Data = jsonString.data(using: .utf8)!
-        let stubUpdate: Update = try! decoder.decode(Update.self, from: data)
+    let decoder: JSONDecoder = JSONDecoder()
+    let data: Data = jsonString.data(using: .utf8)!
+    let stubUpdate: Update = try! decoder.decode(Update.self, from: data)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset settings")
+    let expectation = XCTestExpectation(description: "Reset settings")
 
-        self.client.resetSetting(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset settings")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetSetting(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset settings")
+      }
     }
 
-    // MARK: Synonyms
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetSynonyms() {
+  }
 
-        // Prepare the mock server
+  // MARK: Synonyms
 
-        let jsonString = """
+  func testGetSynonyms() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "wolverine": ["xmen", "logan"],
             "logan": ["wolverine", "xmen"],
@@ -161,52 +164,52 @@ class SettingsTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubSynonyms: [String: [String]] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String: [String]]
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubSynonyms: [String: [String]] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String: [String]]
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get synonyms")
+    let expectation = XCTestExpectation(description: "Get synonyms")
 
-        self.client.getSynonyms(UID: UID) { result in
-            switch result {
-            case .success(let synonyms):
-                XCTAssertEqual(stubSynonyms, synonyms)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get synonyms")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getSynonyms(UID: UID) { result in
+      switch result {
+      case .success(let synonyms):
+        XCTAssertEqual(stubSynonyms, synonyms)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get synonyms")
+      }
     }
 
-    func testUpdateSynonyms() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateSynonyms() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let json = """
+    let json = """
         {
             "wolverine": ["xmen", "logan"],
             "logan": ["wolverine", "xmen"],
@@ -214,181 +217,181 @@ class SettingsTests: XCTestCase {
         }
         """
 
-        let jsonData = json.data(using: .utf8)!
-        let synonyms: [String: [String]] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String: [String]]
+    let jsonData = json.data(using: .utf8)!
+    let synonyms: [String: [String]] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String: [String]]
 
-        let expectation = XCTestExpectation(description: "Update synonyms")
+    let expectation = XCTestExpectation(description: "Update synonyms")
 
-        self.client.updateSynonyms(UID: UID, synonyms) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update synonyms")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateSynonyms(UID: UID, synonyms) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update synonyms")
+      }
     }
 
-    func testResetSynonyms() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetSynonyms() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset synonyms")
+    let expectation = XCTestExpectation(description: "Reset synonyms")
 
-        self.client.resetSynonyms(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset synonyms")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetSynonyms(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset synonyms")
+      }
     }
 
-    // MARK: Stop words
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetStopWords() {
+  }
 
-        // Prepare the mock server
+  // MARK: Stop words
 
-        let jsonString = """
+  func testGetStopWords() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         ["of", "the", "to"]
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubStopWords: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubStopWords: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get stop-words")
+    let expectation = XCTestExpectation(description: "Get stop-words")
 
-        self.client.getStopWords(UID: UID) { result in
-            switch result {
-            case .success(let stopWords):
-                XCTAssertEqual(stubStopWords, stopWords)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get stop-words")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getStopWords(UID: UID) { result in
+      switch result {
+      case .success(let stopWords):
+        XCTAssertEqual(stubStopWords, stopWords)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get stop-words")
+      }
     }
 
-    func testUpdateStopWords() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateStopWords() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let json = """
+    let json = """
         ["of", "the", "to"]
         """
 
-        let stopWords: [String] = try! JSONSerialization.jsonObject(
-          with: json.data(using: .utf8)!, options: []) as! [String]
+    let stopWords: [String] = try! JSONSerialization.jsonObject(
+      with: json.data(using: .utf8)!, options: []) as! [String]
 
-        let expectation = XCTestExpectation(description: "Update stop-words")
+    let expectation = XCTestExpectation(description: "Update stop-words")
 
-        self.client.updateStopWords(UID: UID, stopWords) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update stop-words")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateStopWords(UID: UID, stopWords) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update stop-words")
+      }
     }
 
-    func testResetStopWords() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetStopWords() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset stop-words")
+    let expectation = XCTestExpectation(description: "Reset stop-words")
 
-        self.client.resetStopWords(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset stop-words")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetStopWords(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset stop-words")
+      }
     }
 
-    // MARK: Ranking rules
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetRankingRules() {
+  }
 
-        // Prepare the mock server
+  // MARK: Ranking rules
 
-        let jsonString = """
+  func testGetRankingRules() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         [
             "typo",
             "words",
@@ -400,575 +403,578 @@ class SettingsTests: XCTestCase {
         ]
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubRakingRules: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubRakingRules: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get ranking rules")
+    let expectation = XCTestExpectation(description: "Get ranking rules")
 
-        self.client.getRankingRules(UID: UID) { result in
-            switch result {
-            case .success(let rankingRules):
-                XCTAssertEqual(stubRakingRules, rankingRules)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get ranking rules")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getRankingRules(UID: UID) { result in
+      switch result {
+      case .success(let rankingRules):
+        XCTAssertEqual(stubRakingRules, rankingRules)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get ranking rules")
+      }
     }
 
-    func testUpdateRankingRules() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateRankingRules() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let json = """
+    let json = """
         ["of", "the", "to"]
         """
 
-        let stopWords: [String] = try! JSONSerialization.jsonObject(
-          with: json.data(using: .utf8)!, options: []) as! [String]
+    let stopWords: [String] = try! JSONSerialization.jsonObject(
+      with: json.data(using: .utf8)!, options: []) as! [String]
 
-        let expectation = XCTestExpectation(description: "Update ranking rules")
+    let expectation = XCTestExpectation(description: "Update ranking rules")
 
-        self.client.updateRankingRules(UID: UID, stopWords) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update ranking rules")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateRankingRules(UID: UID, stopWords) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update ranking rules")
+      }
     }
 
-    func testResetRankingRules() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetRankingRules() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset ranking rules")
+    let expectation = XCTestExpectation(description: "Reset ranking rules")
 
-        self.client.resetRankingRules(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset ranking rules")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetRankingRules(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset ranking rules")
+      }
     }
 
-    // MARK: Distinct Attribute
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetDistinctAttribute() {
+  }
 
-        // Prepare the mock server
+  // MARK: Distinct Attribute
 
-        let stubDistinctAttribute: String = """
+  func testGetDistinctAttribute() {
+
+    // Prepare the mock server
+
+    let stubDistinctAttribute: String = """
         "movie_id"
         """
 
-        session.pushData(stubDistinctAttribute)
+    session.pushData(stubDistinctAttribute)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get distinct attribute")
+    let expectation = XCTestExpectation(description: "Get distinct attribute")
 
-        self.client.getDistinctAttribute(UID: UID) { result in
-            switch result {
-            case .success(let distinctAttribute):
-                XCTAssertEqual("movie_id", distinctAttribute!)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get distinct attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getDistinctAttribute(UID: UID) { result in
+      switch result {
+      case .success(let distinctAttribute):
+        XCTAssertEqual("movie_id", distinctAttribute!)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get distinct attribute")
+      }
     }
 
-    func testUpdateDistinctAttribute() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateDistinctAttribute() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let distinctAttribute = "movie_id"
+    let UID: String = "movies"
+    let distinctAttribute = "movie_id"
 
-        let expectation = XCTestExpectation(description: "Update distinct attribute")
+    let expectation = XCTestExpectation(description: "Update distinct attribute")
 
-        self.client.updateDistinctAttribute(UID: UID, distinctAttribute) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update distinct attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateDistinctAttribute(UID: UID, distinctAttribute) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update distinct attribute")
+      }
     }
 
-    func testResetDistinctAttribute() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetDistinctAttribute() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset distinct attribute")
+    let expectation = XCTestExpectation(description: "Reset distinct attribute")
 
-        self.client.resetDistinctAttribute(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset distinct attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetDistinctAttribute(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset distinct attribute")
+      }
     }
 
-    // MARK: Searchable Attribute
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetSearchableAttributes() {
+  }
 
-        // Prepare the mock server
+  // MARK: Searchable Attribute
 
-        let jsonString = """
+  func testGetSearchableAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         ["title", "description", "uid"]
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubSearchableAttribute: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubSearchableAttribute: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get searchable attribute")
+    let expectation = XCTestExpectation(description: "Get searchable attribute")
 
-        self.client.getSearchableAttributes(UID: UID) { result in
-            switch result {
-            case .success(let searchableAttribute):
-                XCTAssertEqual(stubSearchableAttribute, searchableAttribute)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get searchable attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getSearchableAttributes(UID: UID) { result in
+      switch result {
+      case .success(let searchableAttribute):
+        XCTAssertEqual(stubSearchableAttribute, searchableAttribute)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get searchable attribute")
+      }
     }
 
-    func testUpdateSearchableAttributes() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateSearchableAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let json = """
+    let json = """
         ["title", "description", "uid"]
         """
 
-        let jsonData = json.data(using: .utf8)!
-        let searchableAttribute: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = json.data(using: .utf8)!
+    let searchableAttribute: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        let expectation = XCTestExpectation(description: "Update searchable attribute")
+    let expectation = XCTestExpectation(description: "Update searchable attribute")
 
-        self.client.updateSearchableAttributes(UID: UID, searchableAttribute) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update searchable attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateSearchableAttributes(UID: UID, searchableAttribute) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update searchable attribute")
+      }
     }
 
-    func testResetSearchableAttributes() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetSearchableAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset searchable attribute")
+    let expectation = XCTestExpectation(description: "Reset searchable attribute")
 
-        self.client.resetSearchableAttributes(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset searchable attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetSearchableAttributes(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset searchable attribute")
+      }
     }
 
-    // MARK: Displayed Attributes
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetDisplayedAttributes() {
+  }
 
-        // Prepare the mock server
+  // MARK: Displayed Attributes
 
-        let jsonString = """
+  func testGetDisplayedAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         ["title", "description", "release_date", "rank", "poster"]
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
-        let stubDisplayedAttributes: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = jsonString.data(using: .utf8)!
+    let stubDisplayedAttributes: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get displayed attribute")
+    let expectation = XCTestExpectation(description: "Get displayed attribute")
 
-        self.client.getDisplayedAttributes(UID: UID) { result in
-            switch result {
-            case .success(let displayedAttributes):
-                XCTAssertEqual(stubDisplayedAttributes, displayedAttributes)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getDisplayedAttributes(UID: UID) { result in
+      switch result {
+      case .success(let displayedAttributes):
+        XCTAssertEqual(stubDisplayedAttributes, displayedAttributes)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get displayed attribute")
+      }
     }
 
-    func testUpdateDisplayedAttributes() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateDisplayedAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let json = """
+    let json = """
         ["title", "description", "release_date", "rank", "poster"]
         """
 
-        let jsonData = json.data(using: .utf8)!
-        let displayedAttributes: [String] = try! JSONSerialization.jsonObject(
-          with: jsonData, options: []) as! [String]
+    let jsonData = json.data(using: .utf8)!
+    let displayedAttributes: [String] = try! JSONSerialization.jsonObject(
+      with: jsonData, options: []) as! [String]
 
-        let expectation = XCTestExpectation(description: "Update displayed attribute")
+    let expectation = XCTestExpectation(description: "Update displayed attribute")
 
-        self.client.updateDisplayedAttributes(UID: UID, displayedAttributes) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateDisplayedAttributes(UID: UID, displayedAttributes) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update displayed attribute")
+      }
     }
 
-    func testResetDisplayedAttributes() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetDisplayedAttributes() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Reset displayed attribute")
+    let expectation = XCTestExpectation(description: "Reset displayed attribute")
 
-        self.client.resetDisplayedAttributes(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to reset displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetDisplayedAttributes(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to reset displayed attribute")
+      }
     }
 
-    // MARK: Attributes for faceting
+    self.wait(for: [expectation], timeout: 1.0)
 
-    func testGetAttributesForFaceting() {
+  }
 
-        // Prepare the mock server
+  // MARK: Attributes for faceting
 
-        let jsonString = """
+  func testGetAttributesForFaceting() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         ["genre", "director"]
         """
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get displayed attribute")
+    let expectation = XCTestExpectation(description: "Get displayed attribute")
 
-        self.client.getAttributesForFaceting(UID: UID) { result in
-            switch result {
-            case .success(let attributesForFaceting):
-                XCTAssertFalse(attributesForFaceting.isEmpty)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to get displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getAttributesForFaceting(UID: UID) { result in
+      switch result {
+      case .success(let attributesForFaceting):
+        XCTAssertFalse(attributesForFaceting.isEmpty)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to get displayed attribute")
+      }
     }
 
-    func testUpdateAttributesForFaceting() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testUpdateAttributesForFaceting() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":0}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let attributes: [String] = ["genre", "director"]
+    let UID: String = "movies"
+    let attributes: [String] = ["genre", "director"]
 
-        let expectation = XCTestExpectation(description: "Update displayed attribute")
+    let expectation = XCTestExpectation(description: "Update displayed attribute")
 
-        self.client.updateAttributesForFaceting(UID: UID, attributes) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.updateAttributesForFaceting(UID: UID, attributes) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update displayed attribute")
+      }
     }
 
-    func testResetAttributesForFaceting() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testResetAttributesForFaceting() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {"updateId":1}
         """
 
-        let decoder: JSONDecoder = JSONDecoder()
-        let stubUpdate: Update = try! decoder.decode(
-          Update.self,
-          from: jsonString.data(using: .utf8)!)
+    let decoder: JSONDecoder = JSONDecoder()
+    let stubUpdate: Update = try! decoder.decode(
+      Update.self,
+      from: jsonString.data(using: .utf8)!)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Update displayed attribute")
+    let expectation = XCTestExpectation(description: "Update displayed attribute")
 
-        self.client.resetAttributesForFaceting(UID: UID) { result in
-            switch result {
-            case .success(let update):
-                XCTAssertEqual(stubUpdate, update)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to update displayed attribute")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.resetAttributesForFaceting(UID: UID) { result in
+      switch result {
+      case .success(let update):
+        XCTAssertEqual(stubUpdate, update)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to update displayed attribute")
+      }
     }
 
-    private func buildStubSetting(from json: String) -> Setting {
-        let data = json.data(using: .utf8)!
-        let decoder: JSONDecoder = JSONDecoder()
-        return try! decoder.decode(Setting.self, from: data)
-    }
+    self.wait(for: [expectation], timeout: 1.0)
 
-    static var allTests = [
-        ("testShouldInstantiateFromEmptyData", testShouldInstantiateFromEmptyData),
-        ("testGetSetting", testGetSetting),
-        ("testUpdateSetting", testUpdateSetting),
-        ("testResetSetting", testResetSetting),
-        ("testGetSynonyms", testGetSynonyms),
-        ("testUpdateSynonyms", testUpdateSynonyms),
-        ("testResetSynonyms", testResetSynonyms),
-        ("testGetStopWords", testGetStopWords),
-        ("testUpdateStopWords", testUpdateStopWords),
-        ("testResetStopWords", testResetStopWords),
-        ("testGetRankingRules", testGetRankingRules),
-        ("testUpdateRankingRules", testUpdateRankingRules),
-        ("testResetRankingRules", testResetRankingRules),
-        ("testGetDistinctAttribute", testGetDistinctAttribute),
-        ("testUpdateDistinctAttribute", testUpdateDistinctAttribute),
-        ("testResetDistinctAttribute", testResetDistinctAttribute),
-        ("testGetSearchableAttributes", testGetSearchableAttributes),
-        ("testUpdateSearchableAttributes", testUpdateSearchableAttributes),
-        ("testResetSearchableAttributes", testResetSearchableAttributes),
-        ("testGetDisplayedAttributes", testGetDisplayedAttributes),
-        ("testUpdateDisplayedAttributes", testUpdateDisplayedAttributes),
-        ("testResetDisplayedAttributes", testResetDisplayedAttributes),
-        ("testGetAttributesForFaceting", testGetAttributesForFaceting),
-        ("testUpdateAttributesForFaceting", testUpdateAttributesForFaceting),
-        ("testResetAttributesForFaceting", testResetAttributesForFaceting)
-    ]
+  }
+
+  private func buildStubSetting(from json: String) -> Setting {
+    let data = json.data(using: .utf8)!
+    let decoder: JSONDecoder = JSONDecoder()
+    return try! decoder.decode(Setting.self, from: data)
+  }
+
+  static var allTests = [
+    ("testShouldInstantiateFromEmptyData", testShouldInstantiateFromEmptyData),
+    ("testGetSetting", testGetSetting),
+    ("testUpdateSetting", testUpdateSetting),
+    ("testResetSetting", testResetSetting),
+    ("testGetSynonyms", testGetSynonyms),
+    ("testUpdateSynonyms", testUpdateSynonyms),
+    ("testResetSynonyms", testResetSynonyms),
+    ("testGetStopWords", testGetStopWords),
+    ("testUpdateStopWords", testUpdateStopWords),
+    ("testResetStopWords", testResetStopWords),
+    ("testGetRankingRules", testGetRankingRules),
+    ("testUpdateRankingRules", testUpdateRankingRules),
+    ("testResetRankingRules", testResetRankingRules),
+    ("testGetDistinctAttribute", testGetDistinctAttribute),
+    ("testUpdateDistinctAttribute", testUpdateDistinctAttribute),
+    ("testResetDistinctAttribute", testResetDistinctAttribute),
+    ("testGetSearchableAttributes", testGetSearchableAttributes),
+    ("testUpdateSearchableAttributes", testUpdateSearchableAttributes),
+    ("testResetSearchableAttributes", testResetSearchableAttributes),
+    ("testGetDisplayedAttributes", testGetDisplayedAttributes),
+    ("testUpdateDisplayedAttributes", testUpdateDisplayedAttributes),
+    ("testResetDisplayedAttributes", testResetDisplayedAttributes),
+    ("testGetAttributesForFaceting", testGetAttributesForFaceting),
+    ("testUpdateAttributesForFaceting", testUpdateAttributesForFaceting),
+    ("testResetAttributesForFaceting", testResetAttributesForFaceting)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_cast
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/StatsTests.swift
+++ b/Tests/MeiliSearchUnitTests/StatsTests.swift
@@ -1,23 +1,25 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class StatsTests: XCTestCase {
 
-    private var client: MeiliSearch!
+  private var client: MeiliSearch!
 
-    private let session = MockURLSession()
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
 
-    }
+  }
 
-    func testStats() {
+  func testStats() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let jsonString = """
+    let jsonString = """
         {
             "numberOfDocuments": 19654,
             "isIndexing": false,
@@ -31,37 +33,37 @@ class StatsTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubStats: Stat = try! Constants.customJSONDecoder.decode(Stat.self, from: jsonData)
+    let stubStats: Stat = try! Constants.customJSONDecoder.decode(Stat.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let uid: String = "Movies"
+    let uid: String = "Movies"
 
-        let expectation = XCTestExpectation(description: "Check Movies stats")
+    let expectation = XCTestExpectation(description: "Check Movies stats")
 
-        self.client.stat(UID: uid) { result in
-            switch result {
-            case .success(let stats):
-                XCTAssertEqual(stubStats, stats)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to check Movies stats")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.stat(UID: uid) { result in
+      switch result {
+      case .success(let stats):
+        XCTAssertEqual(stubStats, stats)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to check Movies stats")
+      }
     }
 
-    func testAllStats() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testAllStats() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "databaseSize": 447819776,
             "lastUpdate": "2019-11-15T11:15:22.092896Z",
@@ -90,32 +92,34 @@ class StatsTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubAllStats: AllStats = try! Constants.customJSONDecoder.decode(AllStats.self, from: jsonData)
+    let stubAllStats: AllStats = try! Constants.customJSONDecoder.decode(AllStats.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Check all indexes stats")
+    let expectation = XCTestExpectation(description: "Check all indexes stats")
 
-        self.client.allStats { result in
-            switch result {
-            case .success(let allStats):
-                XCTAssertEqual(stubAllStats, allStats)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to check all indexes stats")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.allStats { result in
+      switch result {
+      case .success(let allStats):
+        XCTAssertEqual(stubAllStats, allStats)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to check all indexes stats")
+      }
     }
 
-    static var allTests = [
-        ("testStats", testStats),
-        ("testAllStats", testAllStats)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testStats", testStats),
+    ("testAllStats", testAllStats)
+  ]
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/SystemTests.swift
+++ b/Tests/MeiliSearchUnitTests/SystemTests.swift
@@ -1,108 +1,110 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class SystemTests: XCTestCase {
 
-    private var client: MeiliSearch!
+  private var client: MeiliSearch!
 
-    private let session = MockURLSession()
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testHealthStatusAvailable() {
+  func testHealthStatusAvailable() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let jsonString = """
+    let jsonString = """
         {
             "status": "available"
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let expectedHealthBody: Health = try! Constants.customJSONDecoder.decode(Health.self, from: jsonData)
+    let expectedHealthBody: Health = try! Constants.customJSONDecoder.decode(Health.self, from: jsonData)
 
-        session.pushData(jsonString, code: 200)
+    session.pushData(jsonString, code: 200)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Check body of health server on health method")
+    let expectation = XCTestExpectation(description: "Check body of health server on health method")
 
-        self.client.health { result in
-            switch result {
-            case .success(let body):
-                XCTAssertEqual(expectedHealthBody, body)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed on available status check on health method")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.health { result in
+      switch result {
+      case .success(let body):
+        XCTAssertEqual(expectedHealthBody, body)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed on available status check on health method")
+      }
     }
 
-    func testIsHealthyTrue() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testIsHealthyTrue() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "status": "available"
         }
         """
 
-        session.pushData(jsonString, code: 200)
+    session.pushData(jsonString, code: 200)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Check if is healthy is true")
+    let expectation = XCTestExpectation(description: "Check if is healthy is true")
 
-        self.client.isHealthy { result in
-            if result == true {
-                XCTAssertEqual(result, true)
-                expectation.fulfill()
-            } else {
-                XCTFail("Failed on isHealthy should be true")
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.isHealthy { result in
+      if result == true {
+        XCTAssertEqual(result, true)
+        expectation.fulfill()
+      } else {
+        XCTFail("Failed on isHealthy should be true")
+      }
     }
 
-    func testIsHealthyFalse() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        session.pushData("", code: 400)
+  func testIsHealthyFalse() {
 
-        // Start the test with the mocked server
+    // Prepare the mock server
 
-        let expectation = XCTestExpectation(description: "Check if is healthy is false")
+    session.pushData("", code: 400)
 
-        self.client.isHealthy { result in
-            if result == false {
-                XCTAssertEqual(result, false)
-                expectation.fulfill()
-            } else {
-                XCTFail("Failed on isHealthy should be false")
-            }
-        }
+    // Start the test with the mocked server
 
-        self.wait(for: [expectation], timeout: 1.0)
+    let expectation = XCTestExpectation(description: "Check if is healthy is false")
 
+    self.client.isHealthy { result in
+      if result == false {
+        XCTAssertEqual(result, false)
+        expectation.fulfill()
+      } else {
+        XCTFail("Failed on isHealthy should be false")
+      }
     }
 
-    func testVersion() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let jsonString = """
+  func testVersion() {
+
+    // Prepare the mock server
+
+    let jsonString = """
         {
             "commitSha": "b46889b5f0f2f8b91438a08a358ba8f05fc09fc1",
             "buildDate": "2019-11-15T09:51:54.278247+00:00",
@@ -110,36 +112,38 @@ class SystemTests: XCTestCase {
         }
         """
 
-        let jsonData = jsonString.data(using: .utf8)!
+    let jsonData = jsonString.data(using: .utf8)!
 
-        let stubVersion: Version = try! Constants.customJSONDecoder.decode(Version.self, from: jsonData)
+    let stubVersion: Version = try! Constants.customJSONDecoder.decode(Version.self, from: jsonData)
 
-        session.pushData(jsonString)
+    session.pushData(jsonString)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let expectation = XCTestExpectation(description: "Load server version")
+    let expectation = XCTestExpectation(description: "Load server version")
 
-        self.client.version { result in
+    self.client.version { result in
 
-            switch result {
-            case .success(let version):
-                XCTAssertEqual(stubVersion, version)
-                expectation.fulfill()
-            case .failure:
-                XCTFail("Failed to load server version")
-            }
-
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
+      switch result {
+      case .success(let version):
+        XCTAssertEqual(stubVersion, version)
+        expectation.fulfill()
+      case .failure:
+        XCTFail("Failed to load server version")
+      }
 
     }
 
-    static var allTests = [
-        ("testHealthStatusAvailable", testHealthStatusAvailable),
-        ("testIsHealthyTrue", testIsHealthyTrue),
-        ("testIsHealthyFalse", testIsHealthyFalse),
-        ("testVersion", testVersion)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testHealthStatusAvailable", testHealthStatusAvailable),
+    ("testIsHealthyTrue", testIsHealthyTrue),
+    ("testIsHealthyFalse", testIsHealthyFalse),
+    ("testVersion", testVersion)
+  ]
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchUnitTests/UpdatesTests.swift
@@ -1,21 +1,23 @@
 @testable import MeiliSearch
 import XCTest
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable force_try
 class UpdatesTests: XCTestCase {
 
-    private var client: MeiliSearch!
-    private let session = MockURLSession()
+  private var client: MeiliSearch!
+  private let session = MockURLSession()
 
-    override func setUp() {
-        super.setUp()
-        client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
-    }
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+  }
 
-    func testGetUpdate() {
+  func testGetUpdate() {
 
-        // Prepare the mock server
+    // Prepare the mock server
 
-        let json = """
+    let json = """
         {
             "status": "processed",
             "updateId": 1,
@@ -29,39 +31,39 @@ class UpdatesTests: XCTestCase {
         }
         """
 
-        let data = json.data(using: .utf8)!
+    let data = json.data(using: .utf8)!
 
-        let stubResult: Update.Result = try! Constants.customJSONDecoder.decode(
-          Update.Result.self, from: data)
+    let stubResult: Update.Result = try! Constants.customJSONDecoder.decode(
+      Update.Result.self, from: data)
 
-        session.pushData(json)
+    session.pushData(json)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let update = Update(updateId: 1)
+    let UID: String = "movies"
+    let update = Update(updateId: 1)
 
-        let expectation = XCTestExpectation(description: "Get settings")
+    let expectation = XCTestExpectation(description: "Get settings")
 
-        self.client.getUpdate(UID: UID, update) { result in
-            switch result {
-            case .success(let result):
-                XCTAssertEqual(stubResult, result)
-            case .failure:
-                XCTFail("Failed to get settings")
-            }
-            expectation.fulfill()
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getUpdate(UID: UID, update) { result in
+      switch result {
+      case .success(let result):
+        XCTAssertEqual(stubResult, result)
+      case .failure:
+        XCTFail("Failed to get settings")
+      }
+      expectation.fulfill()
     }
 
-    func testGetUpdateInvalidStatus() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let badStatusUpdateJson = """
+  func testGetUpdateInvalidStatus() {
+
+    // Prepare the mock server
+
+    let badStatusUpdateJson = """
         {
             "status": "something",
             "updateId": 1,
@@ -75,34 +77,34 @@ class UpdatesTests: XCTestCase {
         }
         """
 
-        session.pushData(badStatusUpdateJson)
+    session.pushData(badStatusUpdateJson)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
-        let update = Update(updateId: 1)
+    let UID: String = "movies"
+    let update = Update(updateId: 1)
 
-        let expectation = XCTestExpectation(description: "Get settings")
+    let expectation = XCTestExpectation(description: "Get settings")
 
-        self.client.getUpdate(UID: UID, update) { result in
-            switch result {
-            case .success:
-                XCTFail("The server send a invalid status and it should not succeed")
-            case .failure(let error):
-                XCTAssertTrue(error is Update.Status.StatusError)
-                expectation.fulfill()
-            }
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getUpdate(UID: UID, update) { result in
+      switch result {
+      case .success:
+        XCTFail("The server send a invalid status and it should not succeed")
+      case .failure(let error):
+        XCTAssertTrue(error is Update.Status.StatusError)
+        expectation.fulfill()
+      }
     }
 
-    func testGetAllUpdates() {
+    self.wait(for: [expectation], timeout: 1.0)
 
-        // Prepare the mock server
+  }
 
-        let json = """
+  func testGetAllUpdates() {
+
+    // Prepare the mock server
+
+    let json = """
         [
             {
                 "status": "processed",
@@ -118,35 +120,37 @@ class UpdatesTests: XCTestCase {
         ]
         """
 
-        let data = json.data(using: .utf8)!
+    let data = json.data(using: .utf8)!
 
-        let stubResults: [Update.Result] = try! Constants.customJSONDecoder.decode([Update.Result].self, from: data)
+    let stubResults: [Update.Result] = try! Constants.customJSONDecoder.decode([Update.Result].self, from: data)
 
-        session.pushData(json)
+    session.pushData(json)
 
-        // Start the test with the mocked server
+    // Start the test with the mocked server
 
-        let UID: String = "movies"
+    let UID: String = "movies"
 
-        let expectation = XCTestExpectation(description: "Get settings")
+    let expectation = XCTestExpectation(description: "Get settings")
 
-        self.client.getAllUpdates(UID: UID) { result in
-            switch result {
-            case .success(let results):
-                XCTAssertEqual(stubResults, results)
-            case .failure:
-                XCTFail("Failed to get settings")
-            }
-            expectation.fulfill()
-        }
-
-        self.wait(for: [expectation], timeout: 1.0)
-
+    self.client.getAllUpdates(UID: UID) { result in
+      switch result {
+      case .success(let results):
+        XCTAssertEqual(stubResults, results)
+      case .failure:
+        XCTFail("Failed to get settings")
+      }
+      expectation.fulfill()
     }
 
-    static var allTests = [
-        ("testGetSetting", testGetUpdate),
-        ("testGetAllUpdates", testGetAllUpdates)
-    ]
+    self.wait(for: [expectation], timeout: 1.0)
+
+  }
+
+  static var allTests = [
+    ("testGetSetting", testGetUpdate),
+    ("testGetAllUpdates", testGetAllUpdates)
+  ]
 
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/XCTestManifests.swift
+++ b/Tests/MeiliSearchUnitTests/XCTestManifests.swift
@@ -6,23 +6,23 @@
  
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
-*/
+ */
 
 import XCTest
 
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
-    [
-        testCase(IndexesTests.allTests),
-        testCase(DocumentsTests.allTests),
-        testCase(SearchTests.allTests),
-        testCase(UpdatesTests.allTests),
-        testCase(KeysTests.allTests),
-        testCase(SettingsTests.allTests),
-        testCase(StatsTests.allTests),
-        testCase(SystemTests.allTests),
-        testCase(DumpsTests.allTests),
-        testCase(ClientTests.allTests)
-    ]
+  [
+    testCase(IndexesTests.allTests),
+    testCase(DocumentsTests.allTests),
+    testCase(SearchTests.allTests),
+    testCase(UpdatesTests.allTests),
+    testCase(KeysTests.allTests),
+    testCase(SettingsTests.allTests),
+    testCase(StatsTests.allTests),
+    testCase(SystemTests.allTests),
+    testCase(DumpsTests.allTests),
+    testCase(ClientTests.allTests)
+  ]
 }
 #endif


### PR DESCRIPTION
In this PR the demos and tests are back in the SwiftLint. I tried to exclude the files in the `.swiftlint.yml` file but it did work and resulted in a more complex solution than disabling each broken and acceptable rule in the source code by using `swiftlint:disable rule`.

Rules disabled:

 - `force_try`: During tests it's normal to expect non try values and force unwrapping the initialisations and conversions of data, if it's crashing, there is something wrong with the library or the test is wrong. On the examples, it's Ok to crash the test or demo on the initialisation of the client, but the force conversion of data has been removed to a safe alternative.
 - `force_unwrapping`: Similar as `force_try`.
 - `force_cast`: There are some objects that are being converted to objc values (like `NSError` (or `JSONSerialization` in other tests)) in the `ClientsTests`, converting them with force cast is a part of the test to verify the the expected value matches with the tested value.
 - `line_length`: The `DocumentsTests` unit test is very long, well over 200 lines due the number of spaces, it could be massively reduced but I am afraid of changing it because it's well... not that big, being only 424. I would like to keep this file as an exception to the rule because it's a test, it could be different if it was in the library source code.

Please let me know if this requires any change.