### PR TITLE
Fix issue where settings are being erased and add tests

### DIFF
--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -418,7 +418,7 @@ public struct MeiliSearch {
      */
     public func updateSetting(
         UID: String,
-        _ setting: Setting,
+        _ setting: UpdateSetting,
         _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
         self.settings.update(UID, setting, completion)
     }

--- a/Sources/MeiliSearch/Model/Setting.swift
+++ b/Sources/MeiliSearch/Model/Setting.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+import Foundation
+
 /**
  Each instance of MeiliSearch has three keys: a master, a private, and a public.
  Each key has a given set of permissions on the API routes.
@@ -45,4 +47,104 @@ extension Setting {
         attributesForFaceting = (try? values?.decodeIfPresent([String].self, forKey: .attributesForFaceting)) ?? []
     }
 
+}
+
+public enum Action<T> {
+  case update(_ t: T)
+  case keep
+  func value() -> T {
+    switch self {
+    case .update(let t):
+      return t
+    default:
+      fatalError()
+    }
+  }
+}
+
+/**
+ Each instance of MeiliSearch has three keys: a master, a private, and a public.
+ Each key has a given set of permissions on the API routes.
+ */
+public struct UpdateSetting: Encodable {
+
+    // MARK: Properties
+
+    /// List of ranking rules for a given `Index`.
+    public let rankingRules: Action<[String]>
+
+    /// List of searchable attributes for a given `Index`.
+    public let searchableAttributes: Action<[String]>
+
+    /// List of displayed attributes for a given `Index`.
+    public let displayedAttributes: Action<[String]>
+
+    /// List of stop-words for a given `Index`.
+    public let stopWords: Action<[String]>
+
+    /// List of synonyms and its values for a given `Index`.
+    public let synonyms: Action<[String: [String]]>
+
+    /// Optional distinct attribute set for a given `Index`.
+    public let distinctAttribute: Action<String?>
+
+    /// List of attributes used for the faceting
+    public let attributesForFaceting: Action<[String]>
+  
+    enum CodingKeys: String, CodingKey {
+        case rankingRules, searchableAttributes, displayedAttributes, stopWords, synonyms, distinctAttribute, attributesForFaceting
+    }
+  
+    public init(
+        rankingRules: Action<[String]> = .keep,
+        searchableAttributes: Action<[String]> = .keep,
+        displayedAttributes: Action<[String]> = .keep,
+        stopWords: Action<[String]> = .keep,
+        synonyms: Action<[String: [String]]> = .keep,
+        distinctAttribute: Action<String?> = .keep,
+        attributesForFaceting: Action<[String]> = .keep) {
+        self.rankingRules = rankingRules
+        self.searchableAttributes = searchableAttributes
+        self.displayedAttributes = displayedAttributes
+        self.stopWords = stopWords
+        self.synonyms = synonyms
+        self.distinctAttribute = distinctAttribute
+        self.attributesForFaceting = attributesForFaceting
+    }
+  
+    public init(setting: Setting) {
+        self.rankingRules = .update(setting.rankingRules)
+        self.searchableAttributes = .update(setting.searchableAttributes)
+        self.displayedAttributes = .update(setting.displayedAttributes)
+        self.stopWords = .update(setting.stopWords)
+        self.synonyms = .update(setting.synonyms)
+        self.distinctAttribute = .update(setting.distinctAttribute)
+        self.attributesForFaceting = .update(setting.attributesForFaceting)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      if case let .update(rankingRules) = rankingRules {
+        try container.encode(rankingRules, forKey: .rankingRules)
+      }
+      if case let .update(searchableAttributes) = searchableAttributes {
+        try container.encode(searchableAttributes, forKey: .searchableAttributes)
+      }
+      if case let .update(displayedAttributes) = displayedAttributes {
+        try container.encode(displayedAttributes, forKey: .displayedAttributes)
+      }
+      if case let .update(stopWords) = stopWords {
+        try container.encode(stopWords, forKey: .stopWords)
+      }
+      if case let .update(synonyms) = synonyms {
+        try container.encode(synonyms, forKey: .synonyms)
+      }
+      if case let .update(distinctAttribute) = distinctAttribute {
+        try container.encode(distinctAttribute, forKey: .distinctAttribute)
+      }
+      if case let .update(attributesForFaceting) = attributesForFaceting {
+        try container.encode(attributesForFaceting, forKey: .attributesForFaceting)
+      }
+    }
+  
 }

--- a/Sources/MeiliSearch/Settings.swift
+++ b/Sources/MeiliSearch/Settings.swift
@@ -48,7 +48,7 @@ struct Settings {
 
     func update(
         _ UID: String,
-        _ setting: Setting,
+        _ setting: UpdateSetting,
         _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
 
         let data: Data

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -95,11 +95,11 @@ class SettingsTests: XCTestCase {
         // Start the test with the mocked server
 
         let UID: String = "movies"
-        let setting: Setting = buildStubSetting(from: json)
+        let updateSetting: UpdateSetting = UpdateSetting(setting: buildStubSetting(from: json))
 
         let expectation = XCTestExpectation(description: "Update settings")
 
-        self.client.updateSetting(UID: UID, setting) { result in
+        self.client.updateSetting(UID: UID, updateSetting) { result in
             switch result {
             case .success(let update):
                 XCTAssertEqual(stubUpdate, update)


### PR DESCRIPTION
Hi,

In this PR I fixed the issue where the settings are being deleted, this was happening because the library didn't know the different between the delete, removal and keep of a value. In my solution I had to add the `Action` enum (should I rename it to `Transaction`?) that flags the type of `Action` and a  new struct only used on the update settings. Reusing the same `Setting` struct could make the read from Meilisearch server more complex because everything is wrapped around `Action`.

Unfortunately these are breaking changes. If you have a better solution, please let me know. We could transform all arrays to optional arrays, but it could be a problem with the `distinctAttribute` which is already an optional value.

Regards,
Pedro