### PR TITLE
Change hostURL to host

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -808,7 +808,7 @@ getting_started_create_index_md: |-
   ```
   Example:
   ```swift
-    let client = try! MeiliSearch("http://localhost:7700")
+    let client = try! MeiliSearch(host: "http://localhost:7700")
     client.createIndex(UID: "movies") { (result: Result<Index, Swift.Error>) in
         switch result {
         case .success(let index):
@@ -827,7 +827,7 @@ getting_started_add_documents_md: |-
   ```
   Example:
   ```swift
-    let client = try! MeiliSearch("http://localhost:7700")
+    let client = try! MeiliSearch(host: "http://localhost:7700")
     let documents: Data = /...
     client.addDocuments(UID: "movies", documents: documents) { (result: Result<Update, Swift.Error>) in
         switch result {
@@ -847,7 +847,7 @@ getting_started_search_md: |-
   ```
   Example:
   ```swift
-    let client = try! MeiliSearch("http://localhost:7700")
+    let client = try! MeiliSearch(host: "http://localhost:7700")
     let searchParameters = SearchParameters.query("botman")
     client.search(UID: "movies", searchParameters) { (result: Result<SearchResult<Movie>, Swift.Error>) in
         switch result {

--- a/Demos/PerfectDemo/Sources/PerfectTemplate/main.swift
+++ b/Demos/PerfectDemo/Sources/PerfectTemplate/main.swift
@@ -23,7 +23,7 @@ import MeiliSearch
 import Foundation
 
 // swiftlint:disable force_try
-private let client = try! MeiliSearch(Config.default(apiKey: "masterKey"))
+private let client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
 // swiftlint:disable force_try
 
 private struct Movie: Codable, Equatable {

--- a/Demos/VaporDemo/Sources/App/routes.swift
+++ b/Demos/VaporDemo/Sources/App/routes.swift
@@ -25,7 +25,7 @@ private struct Movie: Codable, Equatable {
 
 func routes(_ app: Application) throws {
 
-  guard let client = try? MeiliSearch("127.0.0.1:7700", "masterKey") else {
+  guard let client = try? MeiliSearch(host: "127.0.0.1:7700", apiKey: "masterKey") else {
     throw NSError(domain: "Failed to initialize MeiliSearch", code: 123)
   }
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import MeiliSearch
 func searchForMovies() {
 
     // Create a new client instance of MeiliSearch.
-    let client = try! MeiliSearch("http://localhost:7700")
+    let client = try! MeiliSearch(host: "http://localhost:7700")
 
     // Create a new search request with "botman" as query.
     let searchParameters = SearchParameters.query("botman")
@@ -93,7 +93,7 @@ func searchForMovies() {
         case .success(let searchResult):
             print(searchResult)
         case .failure(let error):
-            print(error)
+            print(error.localizedDescription)
         }
     }
 

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -32,12 +32,12 @@ public struct MeiliSearch {
   /**
    Create an instance of MeiliSearch client.
 
-   - parameter hostURL:   The host to the MeiliSearch http server.
+   - parameter host:   The host to the MeiliSearch http server.
    - parameter apiKey:    The authorisation key to communicate with MeiliSearch.
    - parameter session:   A custom produced URLSessionProtocol.
    */
-  public init(_ hostURL: String, _ apiKey: String? = nil, _ session: URLSessionProtocol? = nil) throws {
-    self.config = try Config(hostURL: hostURL, apiKey: apiKey, session: session).validate()
+  public init(host: String, apiKey: String? = nil, session: URLSessionProtocol? = nil) throws {
+    self.config = try Config(host: host, apiKey: apiKey, session: session).validate()
     let request: Request = Request(self.config)
     self.indexes = Indexes(request)
     self.documents = Documents(request)

--- a/Sources/MeiliSearch/Config.swift
+++ b/Sources/MeiliSearch/Config.swift
@@ -8,7 +8,7 @@ public class Config {
   // MARK: Properties
 
   /// Address for the MeiliSearch server.
-  let hostURL: String
+  let host: String
 
   /// API key needed for an environment that requires one.
   let apiKey: String?
@@ -19,25 +19,25 @@ public class Config {
   // MARK: Initializers
 
   /**
-   Obtains a Config instance for the given `hostURL` and optional `apiKey`
+   Obtains a Config instance for the given `host` and optional `apiKey`
    with an optional custom `session` URLSessionProtocol.
-   
-   - parameter hostURL:  Address for the MeiliSearch server.
+
+   - parameter host:  Address for the MeiliSearch server.
    - parameter apiKey:   API key needed for the production environment.
    - parameter session:  A custom produced URLSessionProtocol.
    */
   public init(
-    hostURL: String,
+    host: String,
     apiKey: String? = nil,
     session: URLSessionProtocol? = URLSession.shared) {
-    self.hostURL = hostURL
+    self.host = host
     self.apiKey = apiKey
     self.session = session
   }
 
   // MARK: Build URL
 
-  func url(api: String) -> String { hostURL + api }
+  func url(api: String) -> String { host + api }
 
   // MARK: Validate
 
@@ -45,7 +45,7 @@ public class Config {
    Validate if the MeiliSearch provided host is a well formatted URL.
    */
   func validate() throws -> Config {
-    guard URL(string: hostURL) != nil else {
+    guard URL(string: host) != nil else {
       throw MeiliSearch.Error.hostNotValid
     }
     return self

--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -44,7 +44,7 @@ class DocumentsTests: XCTestCase {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch("http://localhost:7700", "masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey:"masterKey")
     }
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -44,7 +44,7 @@ class DocumentsTests: XCTestCase {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch(host: "http://localhost:7700", apiKey:"masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
     }
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
@@ -13,7 +13,7 @@ class DumpsTests: XCTestCase {
   override func setUp() {
     super.setUp()
     if client == nil {
-      client = try! MeiliSearch("http://localhost:7700", "masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
     }
   }
 

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -91,7 +91,7 @@ class SearchTests: XCTestCase {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch("http://localhost:7700", "masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
     }
 
     let documents: Data = try! JSONEncoder().encode(books)

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -29,7 +29,7 @@ class SettingsTests: XCTestCase {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch("http://localhost:7700", "masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
     }
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -35,7 +35,7 @@ class UpdatesTests: XCTestCase {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch("http://localhost:7700", "masterKey")
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
     }
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -8,15 +8,15 @@ class ClientTests: XCTestCase {
 
   func testValidHostURL() {
     session.pushEmpty(code: 200)
-    XCTAssertNotNil(try? MeiliSearch("http://localhost:7700", "masterKey", session))
+    XCTAssertNotNil(try? MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session))
   }
 
   func testWrongHostURL() {
-    XCTAssertNotNil(try MeiliSearch("1234"))
+    XCTAssertNotNil(try MeiliSearch(host: "1234"))
   }
 
   func testNotValidHostURL() {
-    XCTAssertThrowsError(try MeiliSearch("Not valid host")) { error in
+    XCTAssertThrowsError(try MeiliSearch(host: "Not valid host")) { error in
       XCTAssertEqual(error as! MeiliSearch.Error, MeiliSearch.Error.hostNotValid)
     }
   }

--- a/Tests/MeiliSearchUnitTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DocumentsTests.swift
@@ -30,7 +30,7 @@ class DocumentsTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testAddDocuments() {

--- a/Tests/MeiliSearchUnitTests/DumpsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DumpsTests.swift
@@ -10,7 +10,7 @@ class DumpsTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testCreateDump() {

--- a/Tests/MeiliSearchUnitTests/IndexesTests.swift
+++ b/Tests/MeiliSearchUnitTests/IndexesTests.swift
@@ -10,7 +10,7 @@ class IndexesTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testCreateIndex() {

--- a/Tests/MeiliSearchUnitTests/KeysTests.swift
+++ b/Tests/MeiliSearchUnitTests/KeysTests.swift
@@ -10,7 +10,7 @@ class KeysTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testKeys() {

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -28,7 +28,7 @@ class SearchTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testSearchForBotmanMovie() {

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -38,7 +38,7 @@ class SettingsTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   // MARK: Settings

--- a/Tests/MeiliSearchUnitTests/StatsTests.swift
+++ b/Tests/MeiliSearchUnitTests/StatsTests.swift
@@ -11,7 +11,7 @@ class StatsTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
 
   }
 

--- a/Tests/MeiliSearchUnitTests/SystemTests.swift
+++ b/Tests/MeiliSearchUnitTests/SystemTests.swift
@@ -11,7 +11,7 @@ class SystemTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testHealthStatusAvailable() {

--- a/Tests/MeiliSearchUnitTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchUnitTests/UpdatesTests.swift
@@ -10,7 +10,7 @@ class UpdatesTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    client = try! MeiliSearch("http://localhost:7700", "masterKey", session)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
   }
 
   func testGetUpdate() {


### PR DESCRIPTION
fix: #158 

Client is now created the following way: 

```swift
    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
```