### PR TITLE
Add wait for pending update method

### DIFF
--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -391,7 +391,6 @@ public struct MeiliSearch {
     options: WaitOptions? = nil,
     _ completion: @escaping (Result<Update.Result, Swift.Error>
   ) -> Void) {
-    print("et merde")
     self.updates.waitForPendingUpdate(UID, update, options, completion)
   }
 

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -384,7 +384,6 @@ public struct MeiliSearch {
     - parameter: options             Optionnal configuration for timeout and interval
     - parameter completion:          The completion closure used to notify when the server
   **/
-
   public func waitForPendingUpdate(
     UID: String,
     update: Update,

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -373,6 +373,28 @@ public struct MeiliSearch {
     self.updates.getAll(UID, completion)
   }
 
+  /**
+    Wait for an update to be processed or failed.
+
+    Providing an update id, returned by asynchronous MeiliSearch options, call are made
+    to MeiliSearch to check if the update has been processed or if it has failed.
+
+    - parameter UID:                 The unique identifier of the `Index`.
+    - parameter updateId:            The id of the update.
+    - parameter: options             Optionnal configuration for timeout and interval
+    - parameter completion:          The completion closure used to notify when the server
+  **/
+
+  public func waitForPendingUpdate(
+    UID: String,
+    update: Update,
+    options: WaitOptions? = nil,
+    _ completion: @escaping (Result<Update.Result, Swift.Error>
+  ) -> Void) {
+    print("et merde")
+    self.updates.waitForPendingUpdate(UID, update, options, completion)
+  }
+
   // MARK: Keys
 
   /**
@@ -867,5 +889,4 @@ public struct MeiliSearch {
     _ completion: @escaping (Result<Dump, Swift.Error>) -> Void) {
     self.dumps.status(UID, completion)
   }
-
 }

--- a/Sources/MeiliSearch/Error.swift
+++ b/Sources/MeiliSearch/Error.swift
@@ -70,6 +70,7 @@ public extension MeiliSearch {
 
     // TimeOut is reached in a waiting function
     case timeOut(timeOut: Double)
+
     // URL is invalid
     case invalidURL(url: String? = "")
 

--- a/Sources/MeiliSearch/Error.swift
+++ b/Sources/MeiliSearch/Error.swift
@@ -68,6 +68,8 @@ public extension MeiliSearch {
     /// The input or output JSON is invalid.
     case invalidJSON
 
+    // TimeOut is reached in a waiting function
+    case timeOut(timeOut: Double)
     // URL is invalid
     case invalidURL(url: String? = "")
 
@@ -88,6 +90,8 @@ public extension MeiliSearch {
         return "Response decoding failed"
       case .invalidJSON:
         return "Invalid json"
+      case .timeOut(let timeOut):
+        return "TimeOut of \(timeOut) is reached"
       case .invalidURL(let url):
         if let strUrl: String = url {
           return "Invalid URL: \(strUrl)"

--- a/Sources/MeiliSearch/Model/Update.swift
+++ b/Sources/MeiliSearch/Model/Update.swift
@@ -14,6 +14,7 @@ public struct Update: Codable, Equatable {
   public init(updateId: Int) {
     self.updateId = updateId
   }
+
   /// Result type for the Update.
   public struct Result: Codable, Equatable {
 

--- a/Sources/MeiliSearch/Model/Update.swift
+++ b/Sources/MeiliSearch/Model/Update.swift
@@ -11,6 +11,9 @@ public struct Update: Codable, Equatable {
   /// The UID of the update.
   public let updateId: Int
 
+  public init(updateId: Int) {
+    self.updateId = updateId
+  }
   /// Result type for the Update.
   public struct Result: Codable, Equatable {
 

--- a/Sources/MeiliSearch/Model/WaitOptions.swift
+++ b/Sources/MeiliSearch/Model/WaitOptions.swift
@@ -7,19 +7,19 @@ public struct WaitOptions: Codable, Equatable {
 
   // MARK: Properties
 
-  /// Maximum time in seconds before cancel
+  /// Maximum time in seconds before timeOut
   public let timeOut: Double
 
   /// Interval in seconds between each status call
-  public let interval: Double
+  public let interval: TimeInterval
 
   // MARK: Initializers
   public init(
     timeOut: Double? = 5,
-    interval: Double? = 0.05
+    interval: TimeInterval? = 0.5
   ) {
     self.timeOut = timeOut ?? 5
-    self.interval = interval ?? 0.05
+    self.interval = interval ?? 0.5
   }
 
   // MARK: Codable Keys

--- a/Sources/MeiliSearch/Model/WaitOptions.swift
+++ b/Sources/MeiliSearch/Model/WaitOptions.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/**
+ `WaitOptions` struct represent the options used during a waitForPendingUpdate call.
+ */
+public struct WaitOptions: Codable, Equatable {
+
+  // MARK: Properties
+
+  /// Maximum time in seconds before cancel
+  public let timeOut: Double
+
+  /// Interval in seconds between each status call
+  public let interval: Double
+
+  // MARK: Initializers
+  public init(
+    timeOut: Double? = 5,
+    interval: Double? = 0.05
+  ) {
+    self.timeOut = timeOut ?? 5
+    self.interval = interval ?? 0.05
+  }
+
+  // MARK: Codable Keys
+
+  enum CodingKeys: String, CodingKey {
+    case timeOut
+    case interval
+  }
+
+}

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -81,8 +81,7 @@ struct Updates {
         case .success(let status):
           if status.status == Update.Status.processed || status.status == Update.Status.failed {
             completion(.success(status))
-          }
-          else if 0 - startingDate.timeIntervalSinceNow > options.timeOut {
+          } else if 0 - startingDate.timeIntervalSinceNow > options.timeOut {
             completion(.failure(MeiliSearch.Error.timeOut(timeOut: options.timeOut)))
           } else {
             usleep(useconds_t(options.interval * 1000000))
@@ -105,10 +104,10 @@ struct Updates {
 
       self.checkStatus(UID, update, waitOptions, currentDate) { result in
         switch result {
-          case .success(let status):
-            completion(.success(status))
-          case .failure(let error):
-            completion(.failure(error))
+        case .success(let status):
+          completion(.success(status))
+        case .failure(let error):
+          completion(.failure(error))
         }
       }
   }

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -19,12 +19,9 @@ struct Updates {
     _ UID: String,
     _ update: Update,
     _ completion: @escaping (Result<Update.Result, Swift.Error>) -> Void) {
-
     self.request.get(api: "/indexes/\(UID)/updates/\(update.updateId)") { result in
-
       switch result {
       case .success(let data):
-
         guard let data: Data = data else {
           completion(.failure(MeiliSearch.Error.dataNotFound))
           return
@@ -33,7 +30,6 @@ struct Updates {
           let result: Update.Result = try Constants.customJSONDecoder.decode(
             Update.Result.self,
             from: data)
-          print("BEFORE COMPLETION IN GET")
           completion(.success(result))
         } catch {
           completion(.failure(error))
@@ -42,9 +38,7 @@ struct Updates {
       case .failure(let error):
         completion(.failure(error))
       }
-
     }
-
   }
 
   func getAll(
@@ -76,65 +70,47 @@ struct Updates {
     }
   }
 
+  private func checkStatus(
+    _ UID: String,
+    _ update: Update,
+    _ options: WaitOptions,
+    _ startingDate: Date,
+    _ completion: @escaping (Result<Update.Result, Swift.Error>) -> Void) {
+      self.get(UID, update) { result in
+        switch result {
+        case .success(let status):
+          if status.status == Update.Status.processed || status.status == Update.Status.failed {
+            completion(.success(status))
+          }
+          else if 0 - startingDate.timeIntervalSinceNow > options.timeOut {
+            completion(.failure(MeiliSearch.Error.timeOut(timeOut: options.timeOut)))
+          } else {
+            usleep(useconds_t(options.interval * 1000000))
+            self.checkStatus(UID, update, options, startingDate, completion)
+          }
+        case .failure(let error):
+          completion(.failure(error))
+          return
+        }
+      }
+  }
+
   func waitForPendingUpdate(
     _ UID: String,
     _ update: Update,
     _ options: WaitOptions? = nil,
     _ completion: @escaping (Result<Update.Result, Swift.Error>) -> Void) {
-
       let currentDate = Date()
       let waitOptions: WaitOptions = options ?? WaitOptions()
-      var done = false
-      while 0 - currentDate.timeIntervalSinceNow < waitOptions.timeOut || !done {
-        print("1")
-        print(update)
-        let waitForGet = DispatchSemaphore(value: 0)
-        self.get(UID, update) { result in
-          switch result {
+
+      self.checkStatus(UID, update, waitOptions, currentDate) { result in
+        switch result {
           case .success(let status):
-            print("2")
-            if status.status == Update.Status.processed || status.status == Update.Status.failed {
-              print("3")
-              done = true
-              completion(.success(status))
-              waitForGet.signal()
-              return
-            } else {
-              print("4")
-              sleep(1)
-              waitForGet.signal()
-            }
+            completion(.success(status))
           case .failure(let error):
-            print("5")
-            done = true
             completion(.failure(error))
-            waitForGet.signal()
-          }
-          print("6")
         }
-        print("7")
-        if done {
-          return
-        }
-        print("8")
-        waitForGet.wait() // does not work in test env
-        print("9")
       }
-      print("10")
-      completion(.failure(MeiliSearch.Error.timeOut(timeOut: waitOptions.timeOut)))
-      return
   }
 
 }
-
-// completion(.success(Update.Result(
-        //   status: "processed",
-        //   updateId: 1,
-        //   type: Update.Result.UpdateType(
-        //     name: "DocumentsAddition",
-        //     number: 4
-        //   ),
-        //   duration: 0.076980613,
-        //   enqueuedAt: Date("2019-12-07T21:16:09.623944Z"),
-        //   processedAt: Date("2019-12-07T21:16:09.703509Z")
-        // )))

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -29,11 +29,11 @@ struct Updates {
           completion(.failure(MeiliSearch.Error.dataNotFound))
           return
         }
-
         do {
           let result: Update.Result = try Constants.customJSONDecoder.decode(
             Update.Result.self,
             from: data)
+          print("BEFORE COMPLETION IN GET")
           completion(.success(result))
         } catch {
           completion(.failure(error))
@@ -74,7 +74,67 @@ struct Updates {
       }
 
     }
+  }
 
+  func waitForPendingUpdate(
+    _ UID: String,
+    _ update: Update,
+    _ options: WaitOptions? = nil,
+    _ completion: @escaping (Result<Update.Result, Swift.Error>) -> Void) {
+
+      let currentDate = Date()
+      let waitOptions: WaitOptions = options ?? WaitOptions()
+      var done = false
+      while 0 - currentDate.timeIntervalSinceNow < waitOptions.timeOut || !done {
+        print("1")
+        print(update)
+        let waitForGet = DispatchSemaphore(value: 0)
+        self.get(UID, update) { result in
+          switch result {
+          case .success(let status):
+            print("2")
+            if status.status == Update.Status.processed || status.status == Update.Status.failed {
+              print("3")
+              done = true
+              completion(.success(status))
+              waitForGet.signal()
+              return
+            } else {
+              print("4")
+              sleep(1)
+              waitForGet.signal()
+            }
+          case .failure(let error):
+            print("5")
+            done = true
+            completion(.failure(error))
+            waitForGet.signal()
+          }
+          print("6")
+        }
+        print("7")
+        if done {
+          return
+        }
+        print("8")
+        waitForGet.wait() // does not work in test env
+        print("9")
+      }
+      print("10")
+      completion(.failure(MeiliSearch.Error.timeOut(timeOut: waitOptions.timeOut)))
+      return
   }
 
 }
+
+// completion(.success(Update.Result(
+        //   status: "processed",
+        //   updateId: 1,
+        //   type: Update.Result.UpdateType(
+        //     name: "DocumentsAddition",
+        //     number: 4
+        //   ),
+        //   duration: 0.076980613,
+        //   enqueuedAt: Date("2019-12-07T21:16:09.623944Z"),
+        //   processedAt: Date("2019-12-07T21:16:09.703509Z")
+        // )))

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -213,13 +213,11 @@ class UpdatesTests: XCTestCase {
 
   func testWaitForPendingUpdateSuccessWithIntervalZero () {
     let expectation = XCTestExpectation(description: "Wait for pending update with default options")
-    
     self.client.addDocuments(
       UID: self.uid,
       documents: movies,
       primaryKey: nil
     ) { result in
-      
       switch result {
       case .success(let update):
         XCTAssertEqual(Update(updateId: 0), update)
@@ -239,7 +237,6 @@ class UpdatesTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5.0)
   }
 
-  
   func testWaitForPendingUpdateTimeOut () {
     let expectation = XCTestExpectation(description: "Wait for pending update with default options")
 
@@ -248,7 +245,6 @@ class UpdatesTests: XCTestCase {
       documents: movies,
       primaryKey: nil
     ) { result in
-
       switch result {
       case .success(let update):
         XCTAssertEqual(Update(updateId: 0), update)
@@ -260,7 +256,7 @@ class UpdatesTests: XCTestCase {
             print(error.localizedDescription)
             switch error {
             case MeiliSearch.Error.timeOut(let double):
-                XCTAssertEqual(double, 0.0)
+              XCTAssertEqual(double, 0.0)
             default:
               XCTFail("MeiliSearch TimeOut error should have been thrown")
             }

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -75,8 +75,6 @@ class UpdatesTests: XCTestCase {
     self.client.addDocuments(UID: self.uid, documents: documents, primaryKey: nil) { result in
       switch result {
       case .success(let update):
-        print("YOUHOU")
-        print(update)
         self.client.getUpdate(UID: self.uid, update) { (result: Result<Update.Result, Swift.Error>)  in
           switch result {
           case .success(let update):


### PR DESCRIPTION
fixes: #6 

Additions: 
- waitOptions structure to communicate interval and timeOut to waitForPendingUpdate
- New error MeiliSearch.Error.TimeOut in case timeOut is reached
- 