### PR TITLE
Change get/update/resetSetting to get/update/resetSettings with a s

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -153,7 +153,7 @@ get_keys_1: |-
       }
   }
 get_settings_1: |-
-  client.getSetting(UID: "movies") { (result: Result<Setting, Swift.Error>) in
+  client.getSettings(UID: "movies") { (result: Result<Setting, Swift.Error>) in
       switch result {
       case .success(let setting):
           print(setting)
@@ -196,7 +196,7 @@ update_settings_1: |-
       "wolverine": ["xmen", "logan"],
       "logan": ["wolverine"]
   ], acceptNewFields: false)
-  client.updateSetting(UID: "movies", settings) { (result: Result<Update, Swift.Error>) in
+  client.updateSettings(UID: "movies", settings) { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
           print(update)
@@ -205,7 +205,7 @@ update_settings_1: |-
       }
   }
 reset_settings_1: |-
-  client.resetSetting(UID: "movies") { (result: Result<Update, Swift.Error>) in
+  client.resetSettings(UID: "movies") { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
           print(update)

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -453,7 +453,7 @@ public struct MeiliSearch {
    completes the query request, it returns a `Result` object that contains `Setting`
    value. If the request was sucessful or `Error` if a failure occured.
    */
-  public func getSetting(
+  public func getSettings(
     UID: String,
     _ completion: @escaping (Result<SettingResult, Swift.Error>) -> Void) {
     self.settings.get(UID, completion)
@@ -463,12 +463,12 @@ public struct MeiliSearch {
    Update the settings for a given `Index`.
 
    - parameter UID:        The unique identifier for the `Index` to be found.
-   - parameter setting:    Setting to be applied into `Index`.
+   - parameter setting:    Settings to be applied into `Index`.
    - parameter completion: The completion closure used to notify when the server
    completes the query request, it returns a `Result` object that contains `Update`
    value. If the request was sucessful or `Error` if a failure occured.
    */
-  public func updateSetting(
+  public func updateSettings(
     UID: String,
     _ setting: Setting,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
@@ -483,7 +483,7 @@ public struct MeiliSearch {
    completes the query request, it returns a `Result` object that contains `Update`
    value. If the request was sucessful or `Error` if a failure occured.
    */
-  public func resetSetting(
+  public func resetSettings(
     UID: String,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
     self.settings.reset(UID, completion)
@@ -509,7 +509,7 @@ public struct MeiliSearch {
    Update the synonyms for a given `Index`.
 
    - parameter UID:        The unique identifier for the `Index` to be found.
-   - parameter setting:    Setting to be applied into `Index`.
+   - parameter setting:    Settings to be applied into `Index`.
    - parameter completion: The completion closure used to notify when the server
    completes the query request, it returns a `Result` object that contains `Update`
    value. If the request was sucessful or `Error` if a failure occured.

--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -55,7 +55,7 @@ public struct SearchParameters: Codable, Equatable {
     filter: String? = nil,
     sort: [String]? = nil,
     facetsDistribution: [String]? = nil,
-    matches: Bool? = false) {
+    matches: Bool? = nil) {
     self.query = query
     self.offset = offset
     self.limit = limit

--- a/Sources/MeiliSearch/Updates.swift
+++ b/Sources/MeiliSearch/Updates.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /**
- Settings is a list of all the customization possible for an index.
+  Updates contains information related to asynchronous tasks in MeiliSearch
  */
 struct Updates {
 

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -558,7 +558,7 @@ class SearchTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Configure filterable attributes")
 
-    self.client.updateSetting(UID: self.uid, settings) { result in
+    self.client.updateSettings(UID: self.uid, settings) { result in
       switch result {
       case .success(let update):
         waitForPendingUpdate(self.client, self.uid, update) {

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -929,11 +929,11 @@ class SettingsTests: XCTestCase {
 
   // MARK: Global Settings
 
-  func testGetSettings() {
+  func testgetSettingss() {
 
     let expectation = XCTestExpectation(description: "Get current settings")
 
-    self.client.getSetting(UID: self.uid) { result in
+    self.client.getSettings(UID: self.uid) { result in
       switch result {
       case .success(let settings):
         XCTAssertEqual(self.defaultGlobalReturnedSettings, settings)
@@ -948,7 +948,7 @@ class SettingsTests: XCTestCase {
     self.wait(for: [expectation], timeout: 5.0)
   }
 
-  func testUpdateSettings() {
+  func testupdateSettingss() {
     let newSettings = Setting(
       rankingRules: ["words", "typo", "proximity", "attribute", "sort", "exactness"],
       searchableAttributes: ["id", "title"],
@@ -971,11 +971,11 @@ class SettingsTests: XCTestCase {
     )
 
     let expectation = XCTestExpectation(description: "Update settings")
-    self.client.updateSetting(UID: self.uid, newSettings) { result in
+    self.client.updateSettings(UID: self.uid, newSettings) { result in
       switch result {
       case .success(let update):
         waitForPendingUpdate(self.client, self.uid, update) {
-          self.client.getSetting(UID: self.uid) { result in
+          self.client.getSettings(UID: self.uid) { result in
             switch result {
             case .success(let settingResult):
               XCTAssertEqual(expectedSettingResult.rankingRules.sorted(), settingResult.rankingRules.sorted())
@@ -1002,12 +1002,12 @@ class SettingsTests: XCTestCase {
     let overrideSettingsExpectation = XCTestExpectation(description: "Update settings")
 
     // Test if absents settings are sent to MeiliSearch with a nil value.
-    self.client.updateSetting(UID: self.uid, overrideSettings) { result in
+    self.client.updateSettings(UID: self.uid, overrideSettings) { result in
       switch result {
       case .success(let update):
 
         waitForPendingUpdate(self.client, self.uid, update) {
-          self.client.getSetting(UID: self.uid) { result in
+          self.client.getSettings(UID: self.uid) { result in
             switch result {
             case .success(let settingResult):
               XCTAssertEqual(expectedSettingResult.rankingRules.sorted(), settingResult.rankingRules.sorted())
@@ -1031,7 +1031,7 @@ class SettingsTests: XCTestCase {
     self.wait(for: [overrideSettingsExpectation], timeout: 10.0)
   }
 
-  func testUpdateSettingsWithSynonymsAndStopWordsNil() {
+  func testupdateSettingssWithSynonymsAndStopWordsNil() {
 
     let expectation = XCTestExpectation(description: "Update settings")
 
@@ -1055,13 +1055,13 @@ class SettingsTests: XCTestCase {
       filterableAttributes: ["title"],
       sortableAttributes: ["title"])
 
-    self.client.updateSetting(UID: self.uid, newSettings) { result in
+    self.client.updateSettings(UID: self.uid, newSettings) { result in
       switch result {
       case .success(let update):
 
         waitForPendingUpdate(self.client, self.uid, update) {
 
-          self.client.getSetting(UID: self.uid) { result in
+          self.client.getSettings(UID: self.uid) { result in
 
             switch result {
             case .success(let finalSetting):
@@ -1094,17 +1094,17 @@ class SettingsTests: XCTestCase {
     self.wait(for: [expectation], timeout: 10.0)
   }
 
-  func testResetSettings() {
+  func testresetSettingss() {
 
     let expectation = XCTestExpectation(description: "Reset settings")
 
-    self.client.resetSetting(UID: self.uid) { result in
+    self.client.resetSettings(UID: self.uid) { result in
       switch result {
       case .success(let update):
 
         waitForPendingUpdate(self.client, self.uid, update) {
 
-          self.client.getSetting(UID: self.uid) { result in
+          self.client.getSettings(UID: self.uid) { result in
 
             switch result {
             case .success(let settings):

--- a/Tests/MeiliSearchUnitTests/DumpsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DumpsTests.swift
@@ -87,10 +87,6 @@ class DumpsTests: XCTestCase {
 
   }
 
-  static var allTests = [
-    ("testGetDumpStatus", testGetDumpStatus),
-    ("testGetSetting", testGetDumpStatus)
-  ]
 
 }
 // swiftlint:enable force_unwrapping

--- a/Tests/MeiliSearchUnitTests/DumpsTests.swift
+++ b/Tests/MeiliSearchUnitTests/DumpsTests.swift
@@ -87,7 +87,6 @@ class DumpsTests: XCTestCase {
 
   }
 
-
 }
 // swiftlint:enable force_unwrapping
 // swiftlint:enable force_try

--- a/Tests/MeiliSearchUnitTests/SettingsTests.swift
+++ b/Tests/MeiliSearchUnitTests/SettingsTests.swift
@@ -45,7 +45,7 @@ class SettingsTests: XCTestCase {
 
   // MARK: Settings
 
-  func testGetSetting() {
+  func testgetSettings() {
 
     // Prepare the mock server
 
@@ -59,7 +59,7 @@ class SettingsTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Get settings")
 
-    self.client.getSetting(UID: UID) { result in
+    self.client.getSettings(UID: UID) { result in
       switch result {
       case .success(let setting):
         XCTAssertEqual(stubSetting, setting)
@@ -73,7 +73,7 @@ class SettingsTests: XCTestCase {
 
   }
 
-  func testUpdateSetting() {
+  func testupdateSettings() {
 
     // Prepare the mock server
 
@@ -94,7 +94,7 @@ class SettingsTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Update settings")
 
-    self.client.updateSetting(UID: UID, setting) { result in
+    self.client.updateSettings(UID: UID, setting) { result in
       switch result {
       case .success(let update):
         XCTAssertEqual(stubUpdate, update)
@@ -108,7 +108,7 @@ class SettingsTests: XCTestCase {
 
   }
 
-  func testResetSetting() {
+  func testresetSettings() {
 
     // Prepare the mock server
 
@@ -128,7 +128,7 @@ class SettingsTests: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Reset settings")
 
-    self.client.resetSetting(UID: UID) { result in
+    self.client.resetSettings(UID: UID) { result in
       switch result {
       case .success(let update):
         XCTAssertEqual(stubUpdate, update)
@@ -1048,9 +1048,9 @@ class SettingsTests: XCTestCase {
   }
 
   static var allTests = [
-    ("testGetSetting", testGetSetting),
-    ("testUpdateSetting", testUpdateSetting),
-    ("testResetSetting", testResetSetting),
+    ("testgetSettings", testgetSettings),
+    ("testupdateSettings", testupdateSettings),
+    ("testresetSettings", testresetSettings),
     ("testGetSynonyms", testGetSynonyms),
     ("testUpdateSynonyms", testUpdateSynonyms),
     ("testResetSynonyms", testResetSynonyms),


### PR DESCRIPTION
For consistency between SDK the naming of the following methods have been changed: 

- `getSetting` becomes `getSettings`
- `updateSetting` becomes `updateSettings`
- `resetSetting` becomes `resetResstings`
