### PR TITLE
 Update version for the next release (v0.11.0)

### DIFF
--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MeiliSearch'
-  s.version          = '0.10.1'
+  s.version          = '0.11.0'
   s.summary          = 'The MeiliSearch API client written in Swift'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
Since https://github.com/meilisearch/meilisearch-swift/releases has been marked as breaking, update the future version accordingly :) 