### PR TITLE
Add test for filters with spaces

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -674,11 +674,11 @@ class SearchTests: XCTestCase {
     let expectation = XCTestExpectation(description: "Search for Books using filters with a space in the value")
 
     configureFilters {
-      typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+      typealias MeiliResult = Result<SearchResult<Book>, Error>
 
-      let query = "*"
+      let query = ""
       let limit = 5
-      let filter = "genres = High Fantasy"
+      let filter = "genres = 'High fantasy'"
       let parameters = SearchParameters(query: query, limit: limit, filter: filter)
 
       self.index.search(parameters) { (result: MeiliResult) in
@@ -687,6 +687,13 @@ class SearchTests: XCTestCase {
           XCTAssertEqual(documents.query, query)
           XCTAssertEqual(documents.limit, limit)
           XCTAssertEqual(documents.hits.count, 1)
+
+          guard let book: Book = documents.hits.first(where: { book in book.id == 1344 }) else {
+            XCTFail("Failed to search with testSearchFilterWithEmptySpace")
+            return
+          }
+
+          XCTAssertEqual("The Hobbit", book.title)
 
           expectation.fulfill()
 

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -666,10 +666,37 @@ class SearchTests: XCTestCase {
           XCTFail("Failed to search with testSearchFacetsFilters")
         }
       }
+    }
+    self.wait(for: [expectation], timeout: 2.0)
+  }
 
+  func testSearchFilterWithEmptySpace() {
+    let expectation = XCTestExpectation(description: "Search for Books using filters with a space in the value")
+
+    configureFilters {
+      typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+
+      let query = "*"
+      let limit = 5
+      let filter = "genres = High Fantasy"
+      let parameters = SearchParameters(query: query, limit: limit, filter: filter)
+
+      self.index.search(parameters) { (result: MeiliResult) in
+        switch result {
+        case .success(let documents):
+          XCTAssertEqual(documents.query, query)
+          XCTAssertEqual(documents.limit, limit)
+          XCTAssertEqual(documents.hits.count, 1)
+
+          expectation.fulfill()
+
+        case .failure:
+          XCTFail("Failed to search with testSearchFilterWithEmptySpace")
+        }
+      }
     }
 
-    self.wait(for: [expectation], timeout: 2.0)
+    wait(for: [expectation], timeout: 5.0)
   }
 
   // MARK: Facets distribution

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -227,7 +227,7 @@ class SearchTests: XCTestCase {
     // Start the test with the mocked server
     let searchParameters = SearchParameters(
       query: "h",
-      filter: "genre = sci fi",
+      filter: "genre = 'sci fi'",
       sort: ["id:asc"]
     )
 


### PR DESCRIPTION
# Summary

Added a unit test for search queries containing a filter with a value containing a space.

## Miscellaneous

Fixes #210.