### PR TITLE
Use download latest script in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
-      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+      GITHUB_PAT: ${{ secrets.MEILIBOT_PAT_REPO }}
     steps:
       - uses: actions/checkout@v2
       - name: Download the latest stable version of MeiliSearch


### PR DESCRIPTION
Since https://github.com/meilisearch/MeiliSearch/issues/1655 has been fixed into the `download-latest.sh` script, we can use it in the CI