### PR TITLE
Remove SQLite warnings in integration tests

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -33,12 +33,14 @@ class DocumentsTests: XCTestCase {
 
   private var client: MeiliSearch!
   private var index: Indexes!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   override func setUp() {
     super.setUp()
 
-    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+	session = URLSession(configuration: .ephemeral)
+	client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     index = self.client.index(self.uid)
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DumpsTests.swift
@@ -6,6 +6,7 @@ import Foundation
 class DumpsTests: XCTestCase {
 
   private var client: MeiliSearch!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   // MARK: Setup
@@ -13,7 +14,8 @@ class DumpsTests: XCTestCase {
   override func setUp() {
     super.setUp()
     if client == nil {
-      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+      session = URLSession(configuration: .ephemeral)
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     }
   }
 

--- a/Tests/MeiliSearchIntegrationTests/IndexesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/IndexesTests.swift
@@ -5,13 +5,15 @@ import XCTest
 class IndexesTests: XCTestCase {
 
   private var client: MeiliSearch!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   override func setUp() {
     super.setUp()
 
     if client == nil {
-      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+      session = URLSession(configuration: .ephemeral)
+      client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     }
     let getIndexesExp = XCTestExpectation(description: "Try to get all indexes")
     self.client.getIndexes { result in

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -72,6 +72,7 @@ class SearchTests: XCTestCase {
 
   private var client: MeiliSearch!
   private var index: Indexes!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   // MARK: Setup
@@ -79,7 +80,8 @@ class SearchTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+	session = URLSession(configuration: .ephemeral)
+	client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     index = self.client.index(self.uid)
 
     let documents: Data = try! JSONEncoder().encode(books)

--- a/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SettingsTests.swift
@@ -7,6 +7,7 @@ class SettingsTests: XCTestCase {
 
   private var client: MeiliSearch!
   private var index: Indexes!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   private let defaultRankingRules: [String] = [
@@ -32,7 +33,8 @@ class SettingsTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+	session = URLSession(configuration: .ephemeral)
+	client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     index = self.client.index(self.uid)
 
     let expectation = XCTestExpectation(description: "Create index if it does not exist")

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -32,14 +32,15 @@ class UpdatesTests: XCTestCase {
 
   private var client: MeiliSearch!
   private var index: Indexes!
+  private var session: URLSessionProtocol!
   private let uid: String = "books_test"
 
   // MARK: Setup
 
   override func setUp() {
     super.setUp()
-
-    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
+	   session = URLSession(configuration: .ephemeral)
+	   client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     index = self.client.index(self.uid)
     let expectation = XCTestExpectation(description: "Create index if it does not exist")
 

--- a/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/UpdatesTests.swift
@@ -39,8 +39,8 @@ class UpdatesTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-	   session = URLSession(configuration: .ephemeral)
-	   client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
+    session = URLSession(configuration: .ephemeral)
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
     index = self.client.index(self.uid)
     let expectation = XCTestExpectation(description: "Create index if it does not exist")
 


### PR DESCRIPTION
Follows #221 

Fixes #139 