### PR TITLE
Update .code-samples.meilisearch.yaml

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -451,7 +451,7 @@ get_sys_info_1: |-
       }
   }
 distinct_attribute_guide_1: |-
-  client.index("movies").updateDistinctAttribute("product_id") { (result: Result<Update, Swift.Error>) in
+  client.index("jackets").updateDistinctAttribute("product_id") { (result: Result<Update, Swift.Error>) in
       switch result {
       case .success(let update):
           print(update)


### PR DESCRIPTION
Make `distinct_attribute_guide_1` consistent w/ this code sample in other SDKs.

See [this issue](https://github.com/meilisearch/documentation/issues/471#issuecomment-1027733637).