### PR TITLE
ISSUE<259> CHANGED NAMING OF API PATH VARIABLE FROM QUERY TO PATH

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
   dependencies: [
     // Support for dependabot for swift packages in dependabot
     // is in draft mode https://github.com/dependabot/dependabot-core/pull/3772
-    .package(url: "https://github.com/realm/SwiftLint.git", from: "0.43.1")
+    .package(url: "https://github.com/realm/SwiftLint.git", from: "0.43.1"),
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.12.0")
   ],
   targets: [
     .target(

--- a/Sources/MeiliSearch/Documents.swift
+++ b/Sources/MeiliSearch/Documents.swift
@@ -18,7 +18,7 @@ struct Documents {
     _ identifier: String,
     _ completion: @escaping (Result<T, Swift.Error>) -> Void)
   where T: Codable, T: Equatable {
-    let query: String = "/indexes/\(uid)/documents/\(identifier)"
+    let path: String = "/indexes/\(uid)/documents/\(identifier)"
     request.get(api: query) { result in
       switch result {
       case .success(let data):
@@ -44,7 +44,7 @@ struct Documents {
       if let parameters: GetParameters = options {
         queryParameters = try parameters.toQueryParameters()
       }
-      let query: String = "/indexes/\(uid)/documents\(queryParameters)"
+      let path: String = "/indexes/\(uid)/documents\(queryParameters)"
       request.get(api: query) { result in
         switch result {
         case .success(let data):
@@ -70,7 +70,7 @@ struct Documents {
     _ document: Data,
     _ primaryKey: String? = nil,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
-    var query: String = "/indexes/\(uid)/documents"
+    var path: String = "/indexes/\(uid)/documents"
     if let primaryKey: String = primaryKey {
       query += "?primaryKey=\(primaryKey)"
     }
@@ -91,7 +91,7 @@ struct Documents {
     _ encoder: JSONEncoder? = nil,
     _ primaryKey: String? =  nil,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) where T: Encodable {
-    var query: String = "/indexes/\(uid)/documents"
+    var path: String = "/indexes/\(uid)/documents"
     if let primaryKey: String = primaryKey {
       query += "?primaryKey=\(primaryKey)"
     }
@@ -120,7 +120,7 @@ struct Documents {
     _ document: Data,
     _ primaryKey: String? = nil,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) {
-    var query: String = "/indexes/\(uid)/documents"
+    var path: String = "/indexes/\(uid)/documents"
     if let primaryKey: String = primaryKey {
       query += "?primaryKey=\(primaryKey)"
     }
@@ -141,7 +141,7 @@ struct Documents {
     _ encoder: JSONEncoder? = nil,
     _ primaryKey: String? =  nil,
     _ completion: @escaping (Result<Update, Swift.Error>) -> Void) where T: Encodable {
-    var query: String = "/indexes/\(uid)/documents"
+    var path: String = "/indexes/\(uid)/documents"
     if let primaryKey: String = primaryKey {
       query += "?primaryKey=\(primaryKey)"
     }


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes #<259>
(https://github.com/meilisearch/meilisearch-swift/issues/259)

This commit will make a basic change to the variable name from query to path where it was called in the Documents Swift file.

I also added a dependency package (.package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.12.0") to the Package file at the top of the file in Xcode when trying to resolve some errors when trying to run meilisearch. If this was not necessary please tell me.

If there are any problems please contact me on here. I am a new contributor so I apologise if there are any issues with this PR. 

Thank you for your time.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
