### PR TITLE
Update version update in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,11 +119,20 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md).
 
-Make a PR modifying the file [`MeiliSearch.podspec`](/MeiliSearch.podspec) with the right version.
+Make a PR updating the different versions with the new one on these files:
+- [`MeiliSearch.podspec`](/MeiliSearch.podspec):
+  ```ruby
+    s.version          = 'X.X.X'
+  ```
+- [`.code-samples.meilisearch.yaml`](/.code-samples.meilisearch.yaml) on the line containing the following:
+  ```ruby
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "X.X.X")
+  ```
+- [`README.md`](/README.md) on the line containing the following:
+  ```ruby
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "X.X.X")
+  ```
 
-```ruby
-  s.version          = 'X.X.X'
-```
 
 Once the changes are merged on `main`, you can publish the current draft release via the [GitHub interface](https://github.com/meilisearch/meilisearch-swift/releases): on this page, click on `Edit` (related to the draft release) > update the description (be sure you apply [these recommandations](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md#writting-the-release-description)) > when you are ready, click on `Publish release`.
 


### PR DESCRIPTION
The [check-release](https://github.com/meilisearch/meilisearch-swift/blob/main/.github/scripts/check-release.sh) tests ensures that all the mention of the versions of the swift package have been updated before a release. 

Per the contributing it only mentioned one place where to change it. This PR updates with all the lines that must be updated