### PR TITLE
DRY up the shared models between tests

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -4,18 +4,6 @@ import Foundation
 
 // swiftlint:disable force_unwrapping
 // swiftlint:disable force_try
-private struct Movie: Codable, Equatable {
-  let id: Int
-  let title: String
-  let comment: String?
-
-  init(id: Int, title: String, comment: String? = nil) {
-    self.id = id
-    self.title = title
-    self.comment = comment
-  }
-}
-
 private let movies: [Movie] = [
   Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
   Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),

--- a/Tests/MeiliSearchIntegrationTests/KeysTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/KeysTests.swift
@@ -3,18 +3,6 @@ import XCTest
 import Foundation
 
 // swiftlint:disable force_try
-private struct Movie: Codable, Equatable {
-  let id: Int
-  let title: String
-  let comment: String?
-
-  init(id: Int, title: String, comment: String? = nil) {
-    self.id = id
-    self.title = title
-    self.comment = comment
-  }
-}
-
 class KeysTests: XCTestCase {
   private var client: MeiliSearch!
   private var key: String = ""

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -4,55 +4,6 @@ import Foundation
 
 // swiftlint:disable force_unwrapping
 // swiftlint:disable force_try
-private struct Book: Codable, Equatable {
-  let id: Int
-  let title: String
-  let comment: String?
-  let genres: [String]?
-  let formatted: FormattedBook?
-  let matchesInfo: MatchesInfoBook?
-
-  enum CodingKeys: String, CodingKey {
-    case id
-    case title
-    case comment
-    case genres
-    case formatted = "_formatted"
-    case matchesInfo = "_matchesInfo"
-  }
-
-  init(id: Int, title: String, comment: String? = nil, genres: [String] = [], formatted: FormattedBook? = nil, matchesInfo: MatchesInfoBook? = nil) {
-    self.id = id
-    self.title = title
-    self.comment = comment
-    self.genres = genres
-    self.formatted = formatted
-    self.matchesInfo = matchesInfo
-  }
-}
-
-private struct FormattedBook: Codable, Equatable {
-  let id: String
-  let title: String
-  let comment: String?
-
-  init(id: Int, title: String, comment: String? = nil) {
-    self.id = String(id)
-    self.title = title
-    self.comment = comment
-  }
-}
-
-private struct MatchesInfoBook: Codable, Equatable {
-  let comment: [Info]?
-  let title: [Info]?
-}
-
-private struct Info: Codable, Equatable {
-  let start: Int
-  let length: Int
-}
-
 private let books: [Book] = [
   Book(id: 123, title: "Pride and Prejudice", comment: "A great book", genres: ["Classic Regency nove"]),
   Book(id: 456, title: "Le Petit Prince", comment: "A french book", genres: ["Novel"]),

--- a/Tests/MeiliSearchIntegrationTests/Support/Book.swift
+++ b/Tests/MeiliSearchIntegrationTests/Support/Book.swift
@@ -1,0 +1,48 @@
+public struct Book: Codable, Equatable {
+  let id: Int
+  let title: String
+  let comment: String?
+  let genres: [String]?
+  let formatted: FormattedBook?
+  let matchesInfo: MatchesInfoBook?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case comment
+    case genres
+    case formatted = "_formatted"
+    case matchesInfo = "_matchesInfo"
+  }
+
+  init(id: Int, title: String, comment: String? = nil, genres: [String] = [], formatted: FormattedBook? = nil, matchesInfo: MatchesInfoBook? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+    self.genres = genres
+    self.formatted = formatted
+    self.matchesInfo = matchesInfo
+  }
+}
+
+public struct FormattedBook: Codable, Equatable {
+  let id: String
+  let title: String
+  let comment: String?
+
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = String(id)
+    self.title = title
+    self.comment = comment
+  }
+}
+
+public struct MatchesInfoBook: Codable, Equatable {
+  let comment: [Info]?
+  let title: [Info]?
+}
+
+public struct Info: Codable, Equatable {
+  let start: Int
+  let length: Int
+}

--- a/Tests/MeiliSearchIntegrationTests/Support/Movie.swift
+++ b/Tests/MeiliSearchIntegrationTests/Support/Movie.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct Movie: Codable, Equatable {
+  let id: Int
+  let title: String
+  let comment: String?
+
+  init(id: Int, title: String, comment: String? = nil) {
+    self.id = id
+    self.title = title
+    self.comment = comment
+  }
+}

--- a/Tests/MeiliSearchIntegrationTests/TaskTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/TaskTests.swift
@@ -3,18 +3,6 @@ import XCTest
 import Foundation
 
 // swiftlint:disable force_try
-private struct Movie: Codable, Equatable {
-  let id: Int
-  let title: String
-  let comment: String?
-
-  init(id: Int, title: String, comment: String? = nil) {
-    self.id = id
-    self.title = title
-    self.comment = comment
-  }
-}
-
 class TasksTests: XCTestCase {
   private var client: MeiliSearch!
   private var index: Indexes!

--- a/Tests/MeiliSearchIntegrationTests/Utils.swift
+++ b/Tests/MeiliSearchIntegrationTests/Utils.swift
@@ -3,18 +3,6 @@ import XCTest
 @testable import MeiliSearch
 
 // swiftlint:disable force_try
-private struct Movie: Codable, Equatable {
-  let id: Int
-  let title: String
-  let comment: String?
-
-  init(id: Int, title: String, comment: String? = nil) {
-    self.id = id
-    self.title = title
-    self.comment = comment
-  }
-}
-
 private let movies: [Movie] = [
   Movie(id: 123, title: "Pride and Prejudice", comment: "A great book"),
   Movie(id: 456, title: "Le Petit Prince", comment: "A french book"),
@@ -52,30 +40,30 @@ public func waitForTask(
   request()
 }
 
-  public func createGenericIndex(client: MeiliSearch, uid: String, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
-    client.deleteIndex(uid) { result in
-      switch result {
-      case .success:
-        client.createIndex(uid: uid) { result in
-          switch result {
-          case .success(let task):
-            client.waitForTask(task: task, options: WaitOptions(timeOut: 10.0)) { result in
-              switch result {
-              case .success(let task):
-                completion(.success(task))
-              case .failure(let error):
-                completion(.failure(error))
-              }
+public func createGenericIndex(client: MeiliSearch, uid: String, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
+  client.deleteIndex(uid) { result in
+    switch result {
+    case .success:
+      client.createIndex(uid: uid) { result in
+        switch result {
+        case .success(let task):
+          client.waitForTask(task: task, options: WaitOptions(timeOut: 10.0)) { result in
+            switch result {
+            case .success(let task):
+              completion(.success(task))
+            case .failure(let error):
+              completion(.failure(error))
             }
-          case .failure(let error):
-            completion(.failure(error))
           }
+        case .failure(let error):
+          completion(.failure(error))
         }
-      case .failure(let error):
-        completion(.failure(error))
       }
+    case .failure(let error):
+      completion(.failure(error))
     }
   }
+}
 
 public func deleteIndex(client: MeiliSearch, uid: String, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
   client.deleteIndex(uid) { result in
@@ -96,37 +84,37 @@ public func deleteIndex(client: MeiliSearch, uid: String, _ completion: @escapin
   }
 }
 
-  public func addDocuments(client: MeiliSearch, uid: String, primaryKey: String?, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
-    let movie = Movie(id: 1, title: "test", comment: "test movie")
-    addDocuments(client: client, uid: uid, dataset: [movie], primaryKey: primaryKey, completion)
-  }
+public func addDocuments(client: MeiliSearch, uid: String, primaryKey: String?, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
+  let movie = Movie(id: 1, title: "test", comment: "test movie")
+  addDocuments(client: client, uid: uid, dataset: [movie], primaryKey: primaryKey, completion)
+}
 
-  public func addDocuments<T: Encodable>(client: MeiliSearch, uid: String, dataset: [T], primaryKey: String?, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
-    let jsonEncoder = JSONEncoder()
+public func addDocuments<T: Encodable>(client: MeiliSearch, uid: String, dataset: [T], primaryKey: String?, _ completion: @escaping(Result<Task, Swift.Error>) -> Void) {
+  let jsonEncoder = JSONEncoder()
 
-    let documents: Data = try! jsonEncoder.encode(dataset)
-    let index = client.index(uid)
+  let documents: Data = try! jsonEncoder.encode(dataset)
+  let index = client.index(uid)
 
-    client.deleteIndex(uid) { result in
-      switch result {
-      case .success:
-        index.addDocuments(documents: documents, primaryKey: primaryKey) { result in
-          switch result {
-          case .success(let task):
-            client.waitForTask(task: task) { result in
-              switch result {
-              case .success(let task):
-                completion(.success(task))
-              case .failure(let error):
-                completion(.failure(error))
-              }
+  client.deleteIndex(uid) { result in
+    switch result {
+    case .success:
+      index.addDocuments(documents: documents, primaryKey: primaryKey) { result in
+        switch result {
+        case .success(let task):
+          client.waitForTask(task: task) { result in
+            switch result {
+            case .success(let task):
+              completion(.success(task))
+            case .failure(let error):
+              completion(.failure(error))
             }
-          case .failure(let error):
-            completion(.failure(error))
           }
+        case .failure(let error):
+          completion(.failure(error))
         }
-      case .failure(let error):
-        completion(.failure(error))
       }
+    case .failure(let error):
+      completion(.failure(error))
     }
   }
+}


### PR DESCRIPTION
Create a common and shared setup between tests.

These two structs: Book, Movie were defined more than once in multiple occurrences, this increased the burden maintainability of the code and reduced the capability of sharing code among the test suite.
Now they are public and live in a new directory called `MeiliSearchIntegrationTests/Support`.