### PR TITLE
Feature/Add Qualified version

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -5,14 +5,18 @@ current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/')
 file1='MeiliSearch.podspec'
 file2='README.md'
 file3='.code-samples.meilisearch.yaml'
+file4='Sources/MeiliSearch/Model/PackageVersion.swift'
 file_tag1=$(grep '  s.version' $file1 | cut -d '=' -f2 | tr -d "'" | tr -d ' ')
 file_tag2=$(grep '.package(url:' $file2 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
 file_tag3=$(grep '.package(url:' $file3 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
-if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ]; then
+file_tag4=$(grep 'let current' -A 0 $file4 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
+
+if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$file1: found $file_tag1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
-  echo "$file2: found $file_tag3 - expected $current_tag"
+  echo "$file3: found $file_tag3 - expected $current_tag"
+  echo "$file4: found $file_tag4 - expected $current_tag"
   exit 1
 fi
 

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
+      - name: Lint podspec before submitting
+        run: pod spec lint
       - name: Publish to CocoaPods register
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,9 @@ _[Read more about this](https://github.com/meilisearch/integration-guides/blob/m
 ⚠️ Before doing anything, make sure you got through the guide about [Releasing an Integration](https://github.com/meilisearch/integration-guides/blob/main/resources/integration-release.md).
 
 Make a PR updating the different versions with the new one on these files:
-- [`MeiliSearch.podspec`](/MeiliSearch.podspec):
-  ```ruby
-    s.version          = 'X.X.X'
+- [`Sources/MeiliSearch/Model/PackageVersion.swift`](/Sources/MeiliSearch/Model/PackageVersion.swift):
+  ```swift
+    private static let current = "X.X.X"
   ```
 - [`.code-samples.meilisearch.yaml`](/.code-samples.meilisearch.yaml) on the line containing the following:
   ```ruby

--- a/MeiliSearch.podspec
+++ b/MeiliSearch.podspec
@@ -6,9 +6,18 @@
 # To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
 #
 
+# Loads version from `PackageVersion.current` defined in the PackageVersion.swift file.
+package_version = begin
+  File
+    .read("./Sources/MeiliSearch/Model/PackageVersion.swift")
+    .match(/"([0-9]+.[0-9]+.[0-9]+)"/i)[1]
+rescue
+  raise "Cannot retrieve a valid semver.org version in the PackageVersion.swift file"
+end
+
 Pod::Spec.new do |s|
   s.name             = 'MeiliSearch'
-  s.version          = '0.13.0'
+  s.version          = package_version
   s.summary          = 'The Meilisearch API client written in Swift'
 
 # This description is used to generate tags and improve search results.
@@ -33,10 +42,11 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/meilisearch/meilisearch-swift'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Meilisearch' => 'bonjour@meilisearch.com' }
-  s.source           = { :git => 'https://github.com/meilisearch/meilisearch-swift.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/meilisearch/meilisearch-swift.git', :tag => package_version }
   s.social_media_url = 'https://twitter.com/meilisearch'
 
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.{h,m,swift}'
+
   s.swift_versions = ['5.2']
   s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.10'

--- a/Sources/MeiliSearch/Model/PackageVersion.swift
+++ b/Sources/MeiliSearch/Model/PackageVersion.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+internal struct PackageVersion {
+  /// This is the current version of the meilisearch-swift package
+  private static let current = "0.13.0"
+
+  /**
+   Retrieves the current version of the MeiliSearch Swift package and formats accordingly.
+
+   - returns: String containing the qualified version of this package eg. `Meilisearch Swift (v1.0.0)`
+   */
+  static func qualifiedVersion(_ rawVersion: String? = nil) -> String {
+    "Meilisearch Swift (v\(rawVersion ?? self.current))"
+  }
+}

--- a/Tests/MeiliSearchUnitTests/PackageVersionTests.swift
+++ b/Tests/MeiliSearchUnitTests/PackageVersionTests.swift
@@ -1,0 +1,23 @@
+@testable import MeiliSearch
+
+import Foundation
+import XCTest
+
+class PackageVersionTests: XCTestCase {
+  func testAppendsContentsToPrefix() {
+    XCTAssert(PackageVersion.qualifiedVersion().contains("Meilisearch Swift"))
+  }
+
+  func testGetsFullyQualifiedVersion() {
+    XCTAssertEqual(PackageVersion.qualifiedVersion("0.3.2"), "Meilisearch Swift (v0.3.2)")
+  }
+
+  func testChecksForSemVerVersion() {
+    let version = PackageVersion.qualifiedVersion()
+    let regex = "[0-9]+.[0-9]+.[0-9]+"
+
+    let hasSemVer = (version.range(of: regex, options: .regularExpression) ?? nil) != nil
+
+    XCTAssert(hasSemVer, "The PackageVersion.current does not have a valid semver version.")
+  }
+}


### PR DESCRIPTION
- Add a linter to prevent cocoapods errors before publishing the package.
- Add a dynamic version during the cocoapod publishing.
- Update the publishing script to protect tag creation without updating the `PackageVersion.swift`
