### PR TITLE
Fix tests dependent on a specific return order for the documents

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/DocumentsTests.swift
@@ -148,8 +148,8 @@ class DocumentsTests: XCTestCase {
               case .success(let returnedMovies):
                 let returnedMovie = returnedMovies[0]
                 XCTAssertEqual(returnedMovies.count, 1)
-                XCTAssertEqual(returnedMovie.id, 123)
-                XCTAssertEqual(returnedMovie.title, "Pride and Prejudice")
+                XCTAssertEqual(returnedMovie.id, 456)
+                XCTAssertEqual(returnedMovie.title, "Le Petit Prince")
                 XCTAssertEqual(returnedMovie.comment, nil)
                 expectation.fulfill()
               case .failure:

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -757,7 +757,6 @@ class SearchTests: XCTestCase {
             XCTAssertEqual(documents.query, query)
             XCTAssertEqual(documents.limit, limit)
             XCTAssertEqual(documents.hits.count, 0)
-            dump(documents)
             let facetsDistribution = documents.facetsDistribution!
             XCTAssertEqual(["genres": [:]], facetsDistribution)
 

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -87,7 +87,7 @@ class SearchTests: XCTestCase {
         XCTAssertEqual("", response.query)
         XCTAssertEqual(20, response.limit)
         XCTAssertEqual(books.count, response.hits.count)
-        XCTAssertEqual("Alice In Wonderland", response.hits[0].title)
+        XCTAssertEqual("Pride and Prejudice", response.hits[0].title)
         expectation.fulfill()
       case .failure(let error):
         dump(error)
@@ -757,7 +757,7 @@ class SearchTests: XCTestCase {
             XCTAssertEqual(documents.query, query)
             XCTAssertEqual(documents.limit, limit)
             XCTAssertEqual(documents.hits.count, 0)
-
+            dump(documents)
             let facetsDistribution = documents.facetsDistribution!
             XCTAssertEqual(["genres": [:]], facetsDistribution)
 


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/pull/2298 the default returned document order when no relevancy rules are applied has been changed. 