### PR TITLE
Fix failing cropping tests

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -326,7 +326,7 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(documents.limit, limit)
         XCTAssertEqual(documents.hits.count, 1)
         let book: Book = documents.hits[0]
-        XCTAssertEqual("Manuel de Macedo", book.formatted!.comment!)
+        XCTAssertEqual("…Joaquim Manuel de Macedo", book.formatted!.comment!)
         expectation.fulfill()
       case .failure(let error):
         print(error)
@@ -357,7 +357,7 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(documents.hits.count, 2)
 
         let moreninhaBook: Book = documents.hits.first(where: { book in book.id == 1844 })!
-        XCTAssertEqual("A Book from", moreninhaBook.formatted!.comment!)
+        XCTAssertEqual("A Book from Joaquim Manuel…", moreninhaBook.formatted!.comment!)
         expectation.fulfill()
       case .failure(let error):
         dump(error)


### PR DESCRIPTION
As per the changes made in the cropping behavior (now per words see [this spec](https://github.com/meilisearch/specifications/blob/f5c6a8e183e22cc3b80d9a0251c411250f31674f/text/0118-search-api.md#3111-attributestocrop) tests needed to be fixed