### PR TITLE
Add new search parameters highlightPreTag, highlightPostTag and cropMarker

### DIFF
--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -26,8 +26,17 @@ public struct SearchParameters: Codable, Equatable {
   /// Limit length at which to crop specified attributes.
   public let cropLength: Int?
 
+  /// Marker in front and behind a cropped value.
+  public let cropMarker: String?
+
   /// Which attributes to highlight.
   public let attributesToHighlight: [String]?
+
+  /// Tag in front of highlighted term(s).
+  public let highlightPreTag: String?
+
+  /// Tag at the end of highlighted term(s).
+  public let highlightPostTag: String?
 
   /// Filter on attributes values.
   public let filter: String?
@@ -50,7 +59,10 @@ public struct SearchParameters: Codable, Equatable {
     attributesToRetrieve: [String]? = nil,
     attributesToCrop: [String]? = nil,
     cropLength: Int? = nil,
+    cropMarker: String? = nil,
     attributesToHighlight: [String]? = nil,
+    highlightPreTag: String? = nil,
+    highlightPostTag: String? = nil,
     filter: String? = nil,
     sort: [String]? = nil,
     facetsDistribution: [String]? = nil,
@@ -61,7 +73,10 @@ public struct SearchParameters: Codable, Equatable {
     self.attributesToRetrieve = attributesToRetrieve
     self.attributesToCrop = attributesToCrop
     self.cropLength = cropLength
+    self.cropMarker = cropMarker
     self.attributesToHighlight = attributesToHighlight
+    self.highlightPreTag = highlightPreTag
+    self.highlightPostTag = highlightPostTag
     self.filter = filter
     self.sort = sort
     self.facetsDistribution = facetsDistribution
@@ -89,7 +104,10 @@ public struct SearchParameters: Codable, Equatable {
     case attributesToRetrieve
     case attributesToCrop
     case cropLength
+    case cropMarker
     case attributesToHighlight
+    case highlightPreTag
+    case highlightPostTag
     case filter
     case sort
     case facetsDistribution

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -338,6 +338,34 @@ class SearchTests: XCTestCase {
     self.wait(for: [expectation], timeout: TESTS_TIME_OUT)
   }
 
+   // MARK: Crop Marker
+
+  func testSearchCropMarker() {
+    let expectation = XCTestExpectation(description: "Search for Books with a custom crop marker")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let query = "Manuel"
+    let attributesToCrop = ["comment"]
+    let cropLength = 2
+    let cropMarker = "(ꈍᴗꈍ)"
+    let searchParameters = SearchParameters(query: query, attributesToCrop: attributesToCrop, cropLength: cropLength, cropMarker: cropMarker)
+
+    self.index.search(searchParameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        let book: Book = documents.hits[0]
+        XCTAssertEqual("(ꈍᴗꈍ)Joaquim Manuel(ꈍᴗꈍ)", book.formatted!.comment!)
+        expectation.fulfill()
+      case .failure(let error):
+        print(error)
+        XCTFail("Failed to search with a custom crop marker")
+        expectation.fulfill()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: TESTS_TIME_OUT)
+  }
+
   // MARK: Crop length
 
   func testSearchCropLength() {
@@ -431,6 +459,34 @@ class SearchTests: XCTestCase {
       case .failure(let error):
         dump(error)
         XCTFail("Failed to search with testSearchAttributesToHighlight")
+        expectation.fulfill()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: TESTS_TIME_OUT)
+  }
+
+  // MARK: Attributes to highlight
+
+  func testSearchPrePostHighlightTags() {
+    let expectation = XCTestExpectation(description: "Search for Books using custom pre and post highlight tags")
+
+    typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
+    let query = "Joaquim Manuel de Macedo"
+    let attributesToHighlight = ["comment"]
+    let highlightPreTag = "(⊃｡•́‿•̀｡)⊃ "
+    let highlightPostTag = " ⊂(´• ω •`⊂)"
+    let parameters = SearchParameters(query: query, attributesToHighlight: attributesToHighlight, highlightPreTag: highlightPreTag, highlightPostTag: highlightPostTag)
+
+    self.index.search(parameters) { (result: MeiliResult) in
+      switch result {
+      case .success(let documents):
+        let book = documents.hits[0]
+        XCTAssertTrue(book.formatted!.comment!.contains("(⊃｡•́‿•̀｡)⊃ Joaquim ⊂(´• ω •`⊂) (⊃｡•́‿•̀｡)⊃ Manuel ⊂(´• ω •`⊂) (⊃｡•́‿•̀｡)⊃ de ⊂(´• ω •`⊂) (⊃｡•́‿•̀｡)⊃ Macedo ⊂(´• ω •`⊂)"))
+        expectation.fulfill()
+      case .failure(let error):
+        dump(error)
+        XCTFail("Failed to search using custom pre and post highlight tags")
         expectation.fulfill()
       }
     }


### PR DESCRIPTION
As per https://github.com/meilisearch/meilisearch/issues/2214 new search parameters are introduced: 

- `highlightPreTag`
- `highlightPostTag`
- `cropMarker`
