### PR TITLE
Update version for the next release (v0.13.2)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -921,7 +921,7 @@ getting_started_add_documents_md: |-
   Add this to your `Package.swift`:
   ```swift
     dependencies: [
-      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.1")
+      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.2")
     ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once you have your Swift package set up, adding **Meilisearch-Swift** as a depen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.1")
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.2")
 ]
 ```
 

--- a/Sources/MeiliSearch/Model/PackageVersion.swift
+++ b/Sources/MeiliSearch/Model/PackageVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal struct PackageVersion {
   /// This is the current version of the meilisearch-swift package
-  private static let current = "0.13.1"
+  private static let current = "0.13.2"
 
   /**
    Retrieves the current version of the MeiliSearch Swift package and formats accordingly.


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0 :tada:
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.27.0) for more information on the changes.

## 🚀 Enhancements

* Add new search parameters highlightPreTag, highlightPostTag and cropMarker (#288) @bidoubiwa
* Ensure nested fields support (#287)
 @bidoubiwa

Thanks again to @bidoubiwa 🎉
