### PR TITLE
Fix releaser script

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,18 +2,15 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/')
-file1='MeiliSearch.podspec'
 file2='README.md'
 file3='.code-samples.meilisearch.yaml'
 file4='Sources/MeiliSearch/Model/PackageVersion.swift'
-file_tag1=$(grep '  s.version' $file1 | cut -d '=' -f2 | tr -d "'" | tr -d ' ')
 file_tag2=$(grep '.package(url:' $file2 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
 file_tag3=$(grep '.package(url:' $file3 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
 file_tag4=$(grep 'let current' -A 0 $file4 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
 
 if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
-  echo "$file1: found $file_tag1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
   echo "$file3: found $file_tag3 - expected $current_tag"
   echo "$file4: found $file_tag4 - expected $current_tag"

--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,18 +2,18 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | tr -d 'refs/tags/')
-file2='README.md'
-file3='.code-samples.meilisearch.yaml'
-file4='Sources/MeiliSearch/Model/PackageVersion.swift'
+file1='README.md'
+file2='.code-samples.meilisearch.yaml'
+file3='Sources/MeiliSearch/Model/PackageVersion.swift'
+file_tag1=$(grep '.package(url:' $file1 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
 file_tag2=$(grep '.package(url:' $file2 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
-file_tag3=$(grep '.package(url:' $file3 | cut -d ':' -f4 | tr -d '"' | tr -d ')' | tr -d ' ')
-file_tag4=$(grep 'let current' -A 0 $file4 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
+file_tag3=$(grep 'let current' -A 0 $file3 | cut -d '=' -f2 | tr -d '"' | tr -d ' ')
 
-if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ] || [ "$current_tag" != "$file_tag4" ]; then
+if [ "$current_tag" != "$file_tag1" ] || [ "$current_tag" != "$file_tag2" ] || [ "$current_tag" != "$file_tag3" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
+  echo "$file1: found $file_tag1 - expected $current_tag"
   echo "$file2: found $file_tag2 - expected $current_tag"
   echo "$file3: found $file_tag3 - expected $current_tag"
-  echo "$file4: found $file_tag4 - expected $current_tag"
   exit 1
 fi
 


### PR DESCRIPTION
After the implementation of the #276 and #277. 
The `Meilisearch.podspec` does not need to be updated new release, which makes the checking useless.