### PR TITLE
Update version for the next release (v0.13.1)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -921,7 +921,7 @@ getting_started_add_documents_md: |-
   Add this to your `Package.swift`:
   ```swift
     dependencies: [
-      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.0")
+      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.1")
     ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once you have your Swift package set up, adding **Meilisearch-Swift** as a depen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.0")
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.1")
 ]
 ```
 

--- a/Sources/MeiliSearch/Model/PackageVersion.swift
+++ b/Sources/MeiliSearch/Model/PackageVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal struct PackageVersion {
   /// This is the current version of the meilisearch-swift package
-  private static let current = "0.13.0"
+  private static let current = "0.13.1"
 
   /**
    Retrieves the current version of the MeiliSearch Swift package and formats accordingly.


### PR DESCRIPTION
### Release Notes

This version makes this package compatible with Meilisearch v0.26.0 :tada:
Check out the changelog of [Meilisearch v0.26.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.26.0) for more information on the changes.
 
## 🚀 Enhancements

* DRY up the shared models between tests (#274) @brunoocasali
* Feature/Add Qualified version (#276) @brunoocasali
* Feature/Analytics (#277) @brunoocasali
* Fix releaser script (#295) @brunoocasali

Thanks again to @bidoubiwa, @brunoocasali! 🎉
