### PR TITLE
Tasks changes

### DIFF
--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -164,6 +164,14 @@ public struct MeiliSearch {
     self.tasks.waitForTask(task: task, options: options, completion)
   }
 
+  public func waitForTask(
+    task: TaskInfo,
+    options: WaitOptions? = nil,
+    _ completion: @escaping (Result<Task, Swift.Error>
+  ) -> Void) {
+    self.tasks.waitForTask(taskUid: task.uid, options: options, completion)
+  }
+
   // MARK: Tasks
 
  /**
@@ -181,15 +189,17 @@ public struct MeiliSearch {
   }
 
   /**
-   Get all tasks.
+   List tasks based on an optional pagination criteria
 
    - parameter completion: The completion closure used to notify when the server
+   - parameter params: A TasksQuery object with pagination metadata.
    completes the query request, it returns a `Result` object that contains `Key` value.
    If the request was sucessful or `Error` if a failure occured.
    */
   public func getTasks(
+    params: TasksQuery? = nil,
     _ completion: @escaping (Result<Results<Task>, Swift.Error>) -> Void) {
-    self.tasks.getAll(completion)
+    self.tasks.getAll(params: params, completion)
   }
 
   // MARK: Keys

--- a/Sources/MeiliSearch/QueryParameters/TasksQuery.swift
+++ b/Sources/MeiliSearch/QueryParameters/TasksQuery.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public class TasksQuery: Queryable {
+  private var from: Int?
+  private var limit: Int?
+  private var next: Int?
+  private var types: [String]
+  var indexUid: [String]
+  private var status: [String]
+
+  init(limit: Int? = nil, from: Int? = nil, next: Int? = nil, status: [String]? = nil, types: [String]? = nil, indexUid: [String]? = nil) {
+    self.from = from
+    self.limit = limit
+    self.next = next
+    self.status = status ?? []
+    self.types = types ?? []
+    self.indexUid = indexUid ?? []
+  }
+
+  internal func buildQuery() -> [String: Codable?] {
+    [
+      "limit": limit,
+      "from": from,
+      "next": next,
+      "type": types.isEmpty ? nil : types.joined(separator: ","),
+      "status": status.isEmpty ? nil : status.joined(separator: ","),
+      "indexUid": indexUid.isEmpty ? nil : indexUid.joined(separator: ",")
+    ]
+  }
+}

--- a/Sources/MeiliSearch/Tasks.swift
+++ b/Sources/MeiliSearch/Tasks.swift
@@ -21,14 +21,6 @@ struct Tasks {
       get(path: "/tasks/\(taskUid)", completion)
   }
 
-  // Get on index
-  func get(
-    indexUid: String,
-    taskUid: Int,
-    _ completion: @escaping (Result<Task, Swift.Error>) -> Void) {
-      get(path: "/indexes/\(indexUid)/tasks/\(taskUid)", completion)
-  }
-
   private func get (
     path: String,
     _ completion: @escaping (Result<Task, Swift.Error>) -> Void) {
@@ -49,21 +41,34 @@ struct Tasks {
 
   // get all on client
   func getAll(
+    params: TasksQuery? = nil,
     _ completion: @escaping (Result<Results<Task>, Swift.Error>) -> Void) {
-      getAll(path: "/tasks", completion)
+      getAll(path: "/tasks", params: params, completion)
   }
 
   // get all on index
   func getAll(
     uid: String,
+    params: TasksQuery? = nil,
     _ completion: @escaping (Result<Results<Task>, Swift.Error>) -> Void) {
-      getAll(path: "/indexes/\(uid)/tasks", completion)
+      var query: TasksQuery?
+
+      if params != nil {
+        params?.indexUid.append(uid)
+
+        query = params
+      } else {
+        query = TasksQuery(indexUid: [uid])
+      }
+
+      getAll(path: "/tasks", params: query, completion)
   }
 
   private func getAll(
     path: String,
+    params: TasksQuery? = nil,
     _ completion: @escaping (Result<Results<Task>, Swift.Error>) -> Void) {
-    self.request.get(api: path) { result in
+    self.request.get(api: path, param: params?.toQuery()) { result in
       switch result {
       case .success(let data):
         do {

--- a/Tests/MeiliSearchIntegrationTests/Utils.swift
+++ b/Tests/MeiliSearchIntegrationTests/Utils.swift
@@ -47,7 +47,7 @@ public func createGenericIndex(client: MeiliSearch, uid: String, _ completion: @
       client.createIndex(uid: uid) { result in
         switch result {
         case .success(let task):
-          client.waitForTask(task: task, options: WaitOptions(timeOut: 10.0)) { result in
+          client.waitForTask(taskUid: task.uid, options: WaitOptions(timeOut: 10.0)) { result in
             switch result {
             case .success(let task):
               completion(.success(task))
@@ -69,7 +69,7 @@ public func deleteIndex(client: MeiliSearch, uid: String, _ completion: @escapin
   client.deleteIndex(uid) { result in
     switch result {
     case .success(let task):
-      client.waitForTask(task: task) { result in
+      client.waitForTask(taskUid: task.uid) { result in
         switch result {
         case .success(let task):
           completion(.success(task))
@@ -101,7 +101,7 @@ public func addDocuments<T: Encodable>(client: MeiliSearch, uid: String, dataset
       index.addDocuments(documents: documents, primaryKey: primaryKey) { result in
         switch result {
         case .success(let task):
-          client.waitForTask(task: task) { result in
+          client.waitForTask(taskUid: task.uid) { result in
             switch result {
             case .success(let task):
               completion(.success(task))

--- a/Tests/MeiliSearchUnitTests/QueryParameters/TasksQueryTests.swift
+++ b/Tests/MeiliSearchUnitTests/QueryParameters/TasksQueryTests.swift
@@ -1,0 +1,21 @@
+@testable import MeiliSearch
+
+import XCTest
+
+class TasksQueryTests: XCTestCase {
+  func testRenderedQuery() {
+    let data: [[String: TasksQuery]] = [
+      ["?limit=2": TasksQuery(limit: 2)],
+      ["?from=99&limit=2&type=name,title": TasksQuery(limit: 2, from: 99, types: ["name", "title"])],
+      ["?limit=2": TasksQuery(limit: 2, next: nil)],
+      ["?from=2": TasksQuery(from: 2)],
+      ["?indexUid=my-index,123": TasksQuery(indexUid: ["my-index", "123"])],
+      ["?limit=10&next=0": TasksQuery(limit: 10, next: 0)],
+      ["": TasksQuery()]
+    ]
+
+    data.forEach { dict in
+      XCTAssertEqual(dict.first?.value.toQuery(), dict.first?.key)
+    }
+  }
+}

--- a/Tests/MeiliSearchUnitTests/TasksTests.swift
+++ b/Tests/MeiliSearchUnitTests/TasksTests.swift
@@ -1,0 +1,52 @@
+@testable import MeiliSearch
+import XCTest
+
+// swiftlint:disable force_try
+class TasksTests: XCTestCase {
+  private var client: MeiliSearch!
+  private var index: Indexes!
+  private let uid: String = "movies_test"
+  private let session = MockURLSession()
+
+  override func setUp() {
+    super.setUp()
+    client = try! MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey", session: session)
+    index = client.index(self.uid)
+  }
+
+  func testGetTasksWithParametersFromClient() {
+    let jsonString = """
+      {
+        "results": [],
+        "limit": 20,
+        "from": 5,
+        "next": 98
+      }
+      """
+
+    // Prepare the mock server
+    session.pushData(jsonString)
+
+    // Start the test with the mocked server
+    let expectation = XCTestExpectation(description: "Get keys with parameters")
+
+    self.client.getTasks(params: TasksQuery(limit: 20, from: 5, next: 98, types: ["indexCreation"])) { result in
+      switch result {
+      case .success:
+        let requestQuery = self.session.nextDataTask.request?.url?.query
+
+        XCTAssertEqual(requestQuery, "from=5&limit=20&next=98&type=indexCreation")
+
+        expectation.fulfill()
+      case .failure(let error):
+        dump(error)
+        XCTFail("Failed to get all Indexes")
+        expectation.fulfill()
+      }
+    }
+
+    self.wait(for: [expectation], timeout: TESTS_TIME_OUT)
+  }
+}
+// swiftlint:enable force_unwrapping
+// swiftlint:enable force_try


### PR DESCRIPTION
- Create `TasksQuery` to handle query string for /tasks calls
- Add `TasksResults` type to handle the object response in the GET /tasks response.