### PR TITLE
Search changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,8 @@ Output:
         - "Drama"
   - offset: 0
   - limit: 20
-  - nbHits: 1
-  ▿ exhaustiveNbHits: Optional(false)
-    - some: false
-  - facetsDistribution: nil
-  - exhaustiveFacetsCount: nil
+  - estimatedTotalHits: 1
+  - facetDistribution: nil
   ▿ processingTimeMs: Optional(1)
     - some: 1
   ▿ query: Optional("philoudelphia")

--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -45,10 +45,10 @@ public struct SearchParameters: Codable, Equatable {
   public let sort: [String]?
 
   /// Retrieve the count of matching terms for each facets.
-  public let facetsDistribution: [String]?
+  public let facets: [String]?
 
   /// Whether to return the raw matches or not.
-  public let matches: Bool?
+  public let showMatchesPosition: Bool?
 
   // MARK: Initializers
 
@@ -65,8 +65,8 @@ public struct SearchParameters: Codable, Equatable {
     highlightPostTag: String? = nil,
     filter: String? = nil,
     sort: [String]? = nil,
-    facetsDistribution: [String]? = nil,
-    matches: Bool? = nil) {
+    facets: [String]? = nil,
+    showMatchesPosition: Bool? = nil) {
     self.query = query
     self.offset = offset
     self.limit = limit
@@ -79,8 +79,8 @@ public struct SearchParameters: Codable, Equatable {
     self.highlightPostTag = highlightPostTag
     self.filter = filter
     self.sort = sort
-    self.facetsDistribution = facetsDistribution
-    self.matches = matches
+    self.facets = facets
+    self.showMatchesPosition = showMatchesPosition
   }
 
   // MARK: Query Initializers
@@ -110,7 +110,7 @@ public struct SearchParameters: Codable, Equatable {
     case highlightPostTag
     case filter
     case sort
-    case facetsDistribution
-    case matches
+    case facets
+    case showMatchesPosition
   }
 }

--- a/Sources/MeiliSearch/Model/SearchResult.swift
+++ b/Sources/MeiliSearch/Model/SearchResult.swift
@@ -17,16 +17,10 @@ public struct SearchResult<T>: Codable, Equatable where T: Codable, T: Equatable
   public let limit: Int
 
   /// Total number of matches,
-  public let nbHits: Int
-
-  /// Whether `nbHits` is exhaustive.
-  public let exhaustiveNbHits: Bool?
+  public let estimatedTotalHits: Int
 
   /// Distribution of the given facets.
-  public let facetsDistribution: [String: [String: Int]]?
-
-  /// Whether facetDistribution is exhaustive.
-  public let exhaustiveFacetsCount: Bool?
+  public let facetDistribution: [String: [String: Int]]?
 
   /// Time, in milliseconds, to process the query.
   public let processingTimeMs: Int?

--- a/Tests/MeiliSearchIntegrationTests/SearchTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/SearchTests.swift
@@ -372,7 +372,7 @@ class SearchTests: XCTestCase {
         XCTAssertEqual(documents.limit, limit)
         XCTAssertEqual(documents.hits.count, 1)
         let book: Book = documents.hits[0]
-        XCTAssertEqual("…Joaquim Manuel de Macedo", book.formatted!.comment!)
+        XCTAssertEqual("…from Joaquim Manuel de Macedo", book.formatted!.comment!)
         expectation.fulfill()
       case .failure(let error):
         dump(error)
@@ -451,7 +451,7 @@ class SearchTests: XCTestCase {
     typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
     let limit = 5
     let query = "Moreninha"
-    let parameters = SearchParameters(query: query, limit: limit, matches: true)
+    let parameters = SearchParameters(query: query, limit: limit, showMatchesPosition: true)
 
     self.index.search(parameters) { (result: MeiliResult) in
       switch result {
@@ -585,7 +585,7 @@ class SearchTests: XCTestCase {
       distinctAttribute: nil,
       filterableAttributes: filterableAttributes,
       sortableAttributes: ["id"]
-      )
+    )
 
     self.index.updateSettings(settings) { result in
       switch result {
@@ -720,7 +720,7 @@ class SearchTests: XCTestCase {
         typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
         let limit = 5
         let query = "A"
-        let filter = "genres = Novel"
+        let filter = "genres = Fantasy"
         let parameters = SearchParameters(query: query, limit: limit, filter: filter)
 
         self.index.search(parameters) { (result: MeiliResult) in
@@ -729,10 +729,9 @@ class SearchTests: XCTestCase {
             XCTAssertEqual(documents.query, query)
             XCTAssertEqual(documents.limit, limit)
             XCTAssertEqual(documents.hits.count, 2)
-            let moreninhaBook: Book = documents.hits.first { book in book.id == 1844 }!
-            XCTAssertEqual("A Moreninha", moreninhaBook.title)
-            let petitBook: Book = documents.hits.first { book in book.id == 456 }!
-            XCTAssertEqual("Le Petit Prince", petitBook.title)
+
+            XCTAssertEqual(documents.hits.compactMap { $0.title }, ["Alice In Wonderland", "Harry Potter and the Half-Blood Prince"])
+
             expectation.fulfill()
           case .failure(let error):
             dump(error)
@@ -791,9 +790,9 @@ class SearchTests: XCTestCase {
     wait(for: [expectation], timeout: TESTS_TIME_OUT)
   }
 
-  // MARK: Facets distribution
+  // MARK: Facet distribution
 
-  func testSearchFacetsDistribution() {
+  func testSearchFacetDistribution() {
     let expectation = XCTestExpectation(description: "Search for Books using facets distribution")
 
     configureFilters { result in
@@ -802,8 +801,8 @@ class SearchTests: XCTestCase {
         typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
         let limit = 5
         let query = "A"
-        let facetsDistribution = ["genres"]
-        let parameters = SearchParameters(query: query, limit: limit, facetsDistribution: facetsDistribution)
+        let facets = ["genres"]
+        let parameters = SearchParameters(query: query, limit: limit, facets: facets)
 
         self.index.search(parameters) { (result: MeiliResult) in
           switch result {
@@ -812,21 +811,22 @@ class SearchTests: XCTestCase {
             XCTAssertEqual(documents.limit, limit)
             XCTAssertEqual(documents.hits.count, limit)
 
-            let facetsDistribution = documents.facetsDistribution!
+            let facetDistribution = documents.facetDistribution!
             let expected: [String: [String: Int]] = [
               "genres": [
+                "Bildungsroman": 1,
                 "Classic Regency nove": 1,
-                "High fantasy": 1,
                 "Fantasy": 2,
-                "Novel": 2,
-                "Bildungsroman": 1
+                "High fantasy": 1
               ]
             ]
-            XCTAssertEqual(expected, facetsDistribution)
+
+            XCTAssertEqual(facetDistribution["genres"]?.keys.sorted(), expected["genres"]?.keys.sorted())
+            XCTAssertEqual(facetDistribution["genres"]?.values.sorted(), expected["genres"]?.values.sorted())
             expectation.fulfill()
           case .failure(let error):
             dump(error)
-            XCTFail("Failed to search with testSearchFacetsDistribution")
+            XCTFail("Failed to search with testSearchFacetDistribution")
             expectation.fulfill()
           }
         }
@@ -840,7 +840,7 @@ class SearchTests: XCTestCase {
     self.wait(for: [expectation], timeout: 2.0)
   }
 
-  func testSearchFacetsDistributionNullValue() {
+  func testSearchFacetDistributionNullValue() {
     let expectation = XCTestExpectation(description: "Search for Books using facets distribution with 0 value")
 
     configureFilters { result in
@@ -849,9 +849,9 @@ class SearchTests: XCTestCase {
         typealias MeiliResult = Result<SearchResult<Book>, Swift.Error>
         let limit = 5
         let query = "Petit Prince"
-        let facetsDistribution = ["genres"]
+        let facets = ["genres"]
         let filter = "genres = comedy"
-        let parameters = SearchParameters(query: query, limit: limit, filter: filter, facetsDistribution: facetsDistribution)
+        let parameters = SearchParameters(query: query, limit: limit, filter: filter, facets: facets)
 
         self.index.search(parameters) { (result: MeiliResult) in
           switch result {
@@ -859,13 +859,13 @@ class SearchTests: XCTestCase {
             XCTAssertEqual(documents.query, query)
             XCTAssertEqual(documents.limit, limit)
             XCTAssertEqual(documents.hits.count, 0)
-            let facetsDistribution = documents.facetsDistribution!
-            XCTAssertEqual(["genres": [:]], facetsDistribution)
+            let facetDistribution = documents.facetDistribution!
+            XCTAssertEqual(["genres": [:]], facetDistribution)
 
             expectation.fulfill()
           case .failure(let error):
             dump(error)
-            XCTFail("Failed to search with testSearchFacetsDistribution")
+            XCTFail("Failed to search with testSearchFacetDistribution")
             expectation.fulfill()
           }
         }

--- a/Tests/MeiliSearchIntegrationTests/Support/Book.swift
+++ b/Tests/MeiliSearchIntegrationTests/Support/Book.swift
@@ -12,7 +12,7 @@ public struct Book: Codable, Equatable {
     case comment
     case genres
     case formatted = "_formatted"
-    case matchesInfo = "_matchesInfo"
+    case matchesInfo = "_matchesPosition"
   }
 
   init(id: Int, title: String, comment: String? = nil, genres: [String] = [], formatted: FormattedBook? = nil, matchesInfo: MatchesInfoBook? = nil) {

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -52,7 +52,7 @@ class SearchTests: XCTestCase {
         "offset": 0,
         "limit": 20,
         "processingTimeMs": 2,
-        "nbHits": 2,
+        "estimatedTotalHits": 2,
         "query": "botman"
       }
       """
@@ -103,7 +103,7 @@ class SearchTests: XCTestCase {
         "offset": 0,
         "limit": 20,
         "processingTimeMs": 2,
-        "nbHits": 2,
+        "estimatedTotalHits": 2,
         "query": "botman"
       }
       """
@@ -207,7 +207,7 @@ class SearchTests: XCTestCase {
         "offset": 0,
         "limit": 20,
         "processingTimeMs": 2,
-        "nbHits": 1,
+        "estimatedTotalHits": 1,
         "query": "h",
         "genre": "sci fi"
       }
@@ -235,7 +235,7 @@ class SearchTests: XCTestCase {
       switch result {
       case .success(let searchResult):
         XCTAssertEqual(stubSearchResult, searchResult)
-        XCTAssertEqual(searchResult.nbHits, 1)
+        XCTAssertEqual(searchResult.estimatedTotalHits, 1)
         expectation.fulfill()
       case .failure:
         XCTFail("Failed to search for botman")


### PR DESCRIPTION
Fix breaking changes from 0.28 engine version including:

- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `_matchesInfo` response parameter is renamed `_matchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.