### PR TITLE
Remove unused code in KeyTests & Add a cleanup step before KeyTests

### DIFF
--- a/Sources/MeiliSearch/Model/Key.swift
+++ b/Sources/MeiliSearch/Model/Key.swift
@@ -8,7 +8,7 @@ public struct Key: Codable, Equatable {
 
   public let uid: String
   public let name: String?
-  public let description: String
+  public let description: String?
   public let key: String
   public let actions: [String]
   public let indexes: [String]

--- a/Sources/MeiliSearch/Model/KeyParams.swift
+++ b/Sources/MeiliSearch/Model/KeyParams.swift
@@ -4,7 +4,7 @@ import Foundation
  `KeyParams` contains all the parameters to create an API key.
  */
 public struct KeyParams: Codable, Equatable {
-  public let description: String
+  public var description: String?
   public var name: String?
   public var uid: String?
   public let actions: [String]


### PR DESCRIPTION
- Remove all keys before starting a test to prevent order-dependency in the tests
- Make `description` an optional value