### PR TITLE
Update version for the next release (v0.14.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -965,7 +965,7 @@ getting_started_add_documents_md: |-
   Add this to your `Package.swift`:
   ```swift
     dependencies: [
-      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.2")
+      .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.14.0")
     ]
   ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once you have your Swift package set up, adding **Meilisearch-Swift** as a depen
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.13.2")
+    .package(url: "https://github.com/meilisearch/meilisearch-swift.git", from: "0.14.0")
 ]
 ```
 

--- a/Sources/MeiliSearch/Model/PackageVersion.swift
+++ b/Sources/MeiliSearch/Model/PackageVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 internal struct PackageVersion {
   /// This is the current version of the meilisearch-swift package
-  private static let current = "0.13.2"
+  private static let current = "0.14.0"
 
   /**
    Retrieves the current version of the MeiliSearch Swift package and formats accordingly.


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.28.0 :tada:
Check out the changelog of [Meilisearch v0.28.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.28.0) for more information on the changes.

## 💥  Breaking Changes

- `MeiliSearch#getKeys` now returns a `KeysResults`. (#319, #321, #313) @brunoocasali
- `MeiliSearch#getIndexes` now returns a `IndexesResults` (#319, #321, #314) @brunoocasali
- `MeiliSearch#createDump` now responds with a `Result<TaskInfo, Swift.Error>` object. (#319, #321, #311) @brunoocasali
- `MeiliSearch#getDumpStatus` was removed. Use the `MeiliSearch#getTasks` or `MeiliSearch#getTask` instead. (#311) @brunoocasali
- Add `TaskInfo` type to handle enqueued tasks. (#310) @brunoocasali 
- `Dump` type was removed (#311) @brunoocasali.
- `SearchParameters` changes (#317) @brunoocasali
  - Renamed `facetsDistribution` field to `facets`.
  - Renamed `matches` field to `showMatchesPosition`.
- `SearchResult<T>` changes (#317) @brunoocasali
  - Renamed `nbHits` field to `estimatedTotalHits`.
  - Removed `exhaustiveFacetsCount` field.
  - Removed `exhaustiveNbHits` field.
- `Index#getDocuments<T>` now returns an object `DocumentsResults<T>` (#319, #321, #312) @brunoocasali
- `MeiliSearch#getTasks` and `Index#getTasks` now returns an object `TasksResults` (#319, #321, #310, #315) @brunoocasali
- `addDocuments<T>`, `createDump`, `updateSettings` and other methods that "creates" a new task, now responds with a `Result<TaskInfo, Swift.Error>` and therefore they have a `taskUid` instead of `uid` (#310) @brunoocasali
- `MeiliSearch#updateKey` method to update keys now receive a new object `KeyUpdateParams` (#313, #319) @brunoocasali

## 🐛 Enhancements

- `MeiliSearch#getIndexes` now accepts an object with pagination `IndexesQuery`. (#314) @brunoocasali
- `MeiliSearch#getDocuments<T>` now accepts an object with pagination `DocumentsQuery`. (#312) @brunoocasali
- `MeiliSearch#getDocument<T>` now accepts a param called `fields` which takes an array of strings to remap the response. (#312) @brunoocasali
:warning: Be careful with this option since `T` should be able to handle the missing fields.
- `MeiliSearch#createKey` and `MeiliSearch#deleteKey` accepts both `api key` or `api key uid`. (#319, #313) @brunoocasali
- `MeiliSearch#createKey` can optionally specify a `uid:` to generate deterministic API keys. (#319, #313) @brunoocasali

Thanks again to @brunoocasali! 🎉
