### PR TITLE
This commit renamed all the occurence of MEILISEARCH_HOST to MEILISEA…

### DIFF
--- a/Tests/MeiliSearchIntegrationTests/Utils.swift
+++ b/Tests/MeiliSearchIntegrationTests/Utils.swift
@@ -20,7 +20,7 @@ private let movies: [Movie] = [
 public let TESTS_TIME_OUT = 10.0
 
 public func currentHost() -> String {
-  ProcessInfo.processInfo.environment["MEILISEARCH_HOST"] ?? "http://localhost:7700"
+  ProcessInfo.processInfo.environment["MEILISEARCH_URL"] ?? "http://localhost:7700"
 }
 
 public func waitForTask(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     stdin_open: true
     working_dir: /home/package
     environment:
-      - MEILISEARCH_HOST=http://meilisearch:7700
+      - MEILISEARCH_URL=http://meilisearch:7700
     depends_on:
       - meilisearch
     links:


### PR DESCRIPTION
…RCH_URL

# Pull Request

## Related issue
Fixes #339 

## What does this PR do?
- It replace MEILISEARCH_HOST by MEILISEARCH_URL in the docker config

## PR checklist
Please check if your PR fulfils the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
