### PR TITLE
Add async overload for search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,24 +149,13 @@ With the `uid` of the task, you can check the status (`enqueued`, `canceled`, `p
 #### Basic Search <!-- omit in toc -->
 
 ```swift
-
-let semaphore = DispatchSemaphore(value: 0)
-
-// Typealias that represents the result from Meilisearch.
-typealias MeiliResult = Result<SearchResult<Movie>, Swift.Error>
-
-// Call the function search and wait for the closure result.
-client.index("movies").search(SearchParameters( query: "philoudelphia" )) { (result: MeiliResult) in
-    switch result {
-    case .success(let searchResult):
-        dump(searchResult)
-    case .failure(let error):
-        print(error.localizedDescription)
-    }
-    semaphore.signal()
+do {
+  // Call the search function and wait for the result.
+  let result: SearchResult<Movie> = try await client.index("movies").search(SearchParameters(query: "philoudelphia"))
+  dump(result)
+} catch {
+  print(error.localizedDescription)
 }
-semaphore.wait()
-
 ```
 
 Output:
@@ -190,6 +179,8 @@ Output:
 ```
 
 Since Meilisearch is typo-tolerant, the movie `philadelphia` is a valid search response to `philoudelphia`.
+
+> Note: All package APIs support closure-based results for backwards compatibility. Newer async/await variants are being added under [issue 332](https://github.com/meilisearch/meilisearch-swift/issues/332).
 
 ## 🤖 Compatibility with Meilisearch
 

--- a/Sources/MeiliSearch/Async/Indexes+async.swift
+++ b/Sources/MeiliSearch/Async/Indexes+async.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Indexes {
+  /**
+   Search in the index.
+   
+   - Parameter searchParameters: Options on search.
+   - Throws: Error if a failure occurred.
+   - Returns: On completion if the request was successful a `Searchable<T>` instance is returned containing the values.
+   */
+  public func search<T: Codable & Equatable>(_ searchParameters: SearchParameters) async throws -> Searchable<T> {
+    try await withCheckedThrowingContinuation { continuation in
+      self.search.search(self.uid, searchParameters) { result in
+        continuation.resume(with: result)
+      }
+    }
+  }
+}

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -26,7 +26,7 @@ public struct Indexes {
   private let documents: Documents
 
   // Search methods
-  private let search: Search
+  fileprivate let search: Search
 
   // Settings methods
   private let settings: Settings
@@ -1098,6 +1098,26 @@ public struct Indexes {
     ) {
       self.uid = uid
       self.primaryKey = primaryKey
+    }
+  }
+}
+
+// MARK: Swift Concurrency (Async/Await)
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension Indexes {
+  /**
+   Search in the index.
+   
+   - Parameter searchParameters: Options on search.
+   - Throws: Error if a failure occurred.
+   - Returns: On completion if the request was successful a `Searchable<T>` instance is returned containing the values.
+   */
+  public func search<T: Codable & Equatable>(_ searchParameters: SearchParameters) async throws -> Searchable<T> {
+    try await withCheckedThrowingContinuation { continuation in
+      self.search.search(self.uid, searchParameters) { result in
+        continuation.resume(with: result)
+      }
     }
   }
 }

--- a/Sources/MeiliSearch/Indexes.swift
+++ b/Sources/MeiliSearch/Indexes.swift
@@ -26,7 +26,7 @@ public struct Indexes {
   private let documents: Documents
 
   // Search methods
-  fileprivate let search: Search
+  internal let search: Search
 
   // Settings methods
   private let settings: Settings
@@ -1098,26 +1098,6 @@ public struct Indexes {
     ) {
       self.uid = uid
       self.primaryKey = primaryKey
-    }
-  }
-}
-
-// MARK: Swift Concurrency (Async/Await)
-
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension Indexes {
-  /**
-   Search in the index.
-   
-   - Parameter searchParameters: Options on search.
-   - Throws: Error if a failure occurred.
-   - Returns: On completion if the request was successful a `Searchable<T>` instance is returned containing the values.
-   */
-  public func search<T: Codable & Equatable>(_ searchParameters: SearchParameters) async throws -> Searchable<T> {
-    try await withCheckedThrowingContinuation { continuation in
-      self.search.search(self.uid, searchParameters) { result in
-        continuation.resume(with: result)
-      }
     }
   }
 }

--- a/Tests/MeiliSearchUnitTests/SearchTests.swift
+++ b/Tests/MeiliSearchUnitTests/SearchTests.swift
@@ -80,6 +80,46 @@ class SearchTests: XCTestCase {
 
     self.wait(for: [expectation], timeout: TESTS_TIME_OUT)
   }
+  
+  @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+  func testSearchForBotmanMovieAsync() async throws {
+    let jsonString = """
+      {
+        "hits": [
+          {
+            "id": 29751,
+            "title": "Batman Unmasked: The Psychology of the Dark Knight",
+            "poster": "https://image.tmdb.org/t/p/w1280/jjHu128XLARc2k4cJrblAvZe0HE.jpg",
+            "overview": "Delve into the world of Batman and the vigilante justice tha",
+            "release_date": "2020-04-04T19:59:49.259572Z"
+          },
+          {
+            "id": 471474,
+            "title": "Batman: Gotham by Gaslight",
+            "poster": "https://image.tmdb.org/t/p/w1280/7souLi5zqQCnpZVghaXv0Wowi0y.jpg",
+            "overview": "ve Victorian Age Gotham City, Batman begins his war on crime",
+            "release_date": "2020-04-04T19:59:49.259572Z"
+          }
+        ],
+        "offset": 0,
+        "limit": 20,
+        "processingTimeMs": 2,
+        "estimatedTotalHits": 2,
+        "query": "botman"
+      }
+      """
+    
+    // Prepare the mock server
+    let data = jsonString.data(using: .utf8)!
+    let stubSearchResult: Searchable<Movie> = try! Constants.customJSONDecoder.decode(Searchable<Movie>.self, from: data)
+    session.pushData(jsonString)
+    
+    // Start the test with the mocked server
+    let searchParameters = SearchParameters.query("botman")
+    
+    let searchResult: Searchable<Movie> = try await self.index.search(searchParameters)
+    XCTAssertEqual(stubSearchResult, searchResult)
+  }
 
   func testSearchForBotmanMovieFacets() {
     let jsonString = """


### PR DESCRIPTION
# Pull Request

⚠️ I've marked this as draft as it current works to provide an example of how we could add async/await support to the library. I am more than happy to expand this to **all** currently supported APIs.

## Related issue

Relates to #332 (doesn't close as only adds support for one API)

## What does this PR do?
- Adds an async/await override to an existing search API providing users with more choice.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
