### PR TITLE
Add `total` to TasksResult

### DIFF
--- a/Sources/MeiliSearch/Model/TasksResults.swift
+++ b/Sources/MeiliSearch/Model/TasksResults.swift
@@ -13,4 +13,6 @@ public struct TasksResults: Codable, Equatable {
   public let from: Int?
   /// Max number of records to be returned in one request.
   public let limit: Int
+  /// The total number of tasks.
+  public let total: Int
 }

--- a/Tests/MeiliSearchIntegrationTests/TaskTests.swift
+++ b/Tests/MeiliSearchIntegrationTests/TaskTests.swift
@@ -75,6 +75,7 @@ class TasksTests: XCTestCase {
               case .success(let tasks):
                 // Only one because index has been deleted and recreated
                 XCTAssertEqual(tasks.results.count, 1)
+                XCTAssertEqual(tasks.total, 1)
                 expectation.fulfill()
               case .failure(let error):
                 dump(error)

--- a/Tests/MeiliSearchUnitTests/IndexesTests.swift
+++ b/Tests/MeiliSearchUnitTests/IndexesTests.swift
@@ -240,7 +240,8 @@ class IndexesTests: XCTestCase {
         "results": [],
         "limit": 20,
         "from": 5,
-        "next": 98
+        "next": 98,
+        "total": 4
       }
       """
 

--- a/Tests/MeiliSearchUnitTests/TasksTests.swift
+++ b/Tests/MeiliSearchUnitTests/TasksTests.swift
@@ -20,7 +20,8 @@ class TasksTests: XCTestCase {
         "results": [],
         "limit": 20,
         "from": 5,
-        "next": 98
+        "next": 98,
+        "total": 4
       }
       """
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #402

## What does this PR do?
- Adds support for new `total` attribute to GET tasks request. This is a recent addition, and so it may be desired to make this optional for backwards compatibility.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
