### PR TITLE
Add support for search ranking score

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -169,7 +169,7 @@ async_guide_canceled_by: |-
     }
   }
 search_parameter_guide_hitsperpage_1: |-
-  let searchParameters = SearchParameters.query("", hitsPerPage: 15)
+  let searchParameters = SearchParameters(query: "", hitsPerPage: 15)
   client.index("movies").search(searchParameters) { (result: Result<Searchable<Movie>, Swift.Error>) in
     switch result {
     case .success(let searchResult):
@@ -179,7 +179,7 @@ search_parameter_guide_hitsperpage_1: |-
     }
   }
 search_parameter_guide_page_1: |-
-  let searchParameters = SearchParameters.query("", page: 15)
+  let searchParameters = SearchParameters(query: "", page: 15)
   client.index("movies").search(searchParameters) { (result: Result<Searchable<Movie>, Swift.Error>) in
     switch result {
     case .success(let searchResult):
@@ -194,6 +194,16 @@ search_parameter_guide_attributes_to_search_on_1: |-
     switch result {
     case .success(let searchResult):
         print(searchResult)
+    case .failure(let error):
+        print(error)
+    }
+  }
+search_parameter_guide_show_ranking_score_1: |-
+  let searchParameters = SearchParameters(query: "dragon", showRankingScore: true)
+  client.index("movies").search(searchParameters) { (result: Result<Searchable<Movie>, Swift.Error>) in
+    switch result {
+    case .success(let searchResult):
+        print(searchResult.rankingScore)
     case .failure(let error):
         print(error)
     }

--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -62,6 +62,9 @@ public struct SearchParameters: Codable, Equatable {
   /// Whether to return the raw matches or not.
   public let showMatchesPosition: Bool?
 
+  /// Whether to return the search ranking score or not.
+  public let showRankingScore: Bool?
+
   // MARK: Initializers
 
   public init(
@@ -81,7 +84,8 @@ public struct SearchParameters: Codable, Equatable {
     filter: String? = nil,
     sort: [String]? = nil,
     facets: [String]? = nil,
-    showMatchesPosition: Bool? = nil) {
+    showMatchesPosition: Bool? = nil,
+    showRankingScore: Bool? = nil) {
     self.query = query
     self.offset = offset
     self.limit = limit
@@ -99,6 +103,7 @@ public struct SearchParameters: Codable, Equatable {
     self.sort = sort
     self.facets = facets
     self.showMatchesPosition = showMatchesPosition
+    self.showRankingScore = showRankingScore
   }
 
   // MARK: Query Initializers
@@ -133,5 +138,6 @@ public struct SearchParameters: Codable, Equatable {
     case showMatchesPosition
     case hitsPerPage
     case page
+    case showRankingScore
   }
 }

--- a/Sources/MeiliSearch/Model/SearchResult.swift
+++ b/Sources/MeiliSearch/Model/SearchResult.swift
@@ -11,7 +11,7 @@ public class Searchable<T>: Equatable, Codable where T: Codable, T: Equatable {
   // MARK: Properties
 
   /// Possible hints from the search query.
-  public var hits: [T] = []
+  public var hits: [SearchHit<T>] = []
 
   /// Distribution of the given facets.
   public var facetDistribution: [String: [String: Int]]?
@@ -31,6 +31,37 @@ public class Searchable<T>: Equatable, Codable where T: Codable, T: Equatable {
     case facetStats
     case processingTimeMs
     case query
+  }
+}
+
+@dynamicMemberLookup
+public struct SearchHit<T>: Equatable, Codable where T: Codable, T: Equatable {
+  public let result: T
+  public let rankingScore: Double?
+
+  /// Dynamic member lookup is used to allow easy access to instance members of the hit result, maintaining a level of backwards compatibility.
+  public subscript<V>(dynamicMember keyPath: KeyPath<T, V>) -> V {
+    result[keyPath: keyPath]
+  }
+
+  // MARK: Codable
+
+  enum CodingKeys: String, CodingKey {
+    case rankingScore = "_rankingScore"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.result = try T(from: decoder)
+    self.rankingScore = try container.decodeIfPresent(Double.self, forKey: .rankingScore)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(result)
+
+    var containerTwo = encoder.container(keyedBy: CodingKeys.self)
+    try containerTwo.encodeIfPresent(rankingScore, forKey: .rankingScore)
   }
 }
 

--- a/Sources/MeiliSearch/Model/SearchResult.swift
+++ b/Sources/MeiliSearch/Model/SearchResult.swift
@@ -36,12 +36,12 @@ public class Searchable<T>: Equatable, Codable where T: Codable, T: Equatable {
 
 @dynamicMemberLookup
 public struct SearchHit<T>: Equatable, Codable where T: Codable, T: Equatable {
-  public let result: T
-  public let rankingScore: Double?
+  public let document: T
+  public internal(set) var rankingScore: Double?
 
   /// Dynamic member lookup is used to allow easy access to instance members of the hit result, maintaining a level of backwards compatibility.
   public subscript<V>(dynamicMember keyPath: KeyPath<T, V>) -> V {
-    result[keyPath: keyPath]
+    document[keyPath: keyPath]
   }
 
   // MARK: Codable
@@ -52,13 +52,13 @@ public struct SearchHit<T>: Equatable, Codable where T: Codable, T: Equatable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    self.result = try T(from: decoder)
+    self.document = try T(from: decoder)
     self.rankingScore = try container.decodeIfPresent(Double.self, forKey: .rankingScore)
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(result)
+    try container.encode(document)
 
     var containerTwo = encoder.container(keyedBy: CodingKeys.self)
     try containerTwo.encodeIfPresent(rankingScore, forKey: .rankingScore)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #398

## What does this PR do?
- Add the ability receive a new param in the search method called showRankingScore.
- Add the ability handle the new _rankingScore key/value in the search hits' response.
- Add integration tests
- Update the code-samples accordingly

⚠️  **This is a breaking change**.

I'd love to hear some thoughts from others on how we may be able to avoid this kind of breaking change, but with #398 and #399 new values are being added to the "hit" object. The hit object is currently a generic provided by the user of the library, and as such it's impossible for us to add new attributes to that.

In this PR I've tried to get around this by creating our own encapsulation called "SearchHit" which itself holds a reference to the actual result but also any additional attributes that Meilisearch itself returns. In order to minimise the impact on users of the library I have implemented a "dynamic member lookup" with a keypath, this continues to support (in a completely type safe and compiler safe way) dot notation to variables within the hit result. Which means `hits[0].title` would still return the title on the hit, even though architecturally it's address is `hits[0].result.title`. While this does work for the vast majority of use cases, we are unable to support the case where a user tries to cast a hit to a type, you can see this in our tests where you can no longer cast `hits[0]` to a "Book", rather it is now a "SearchHit<Book>", but again... you can access variables the same and no other changes are needed to the code.

Importantly though this workaround with dynamic member lookups is limited to the capabilities of keypaths, which as documented officially by Apple [here](https://github.com/apple/swift/blob/main/test/attr/attr_dynamic_member_lookup.swift#L671-L672) does not include methods. As such where users have functions within their models, they would have to call that through `hits[0].result.someFunction()`.

I do personally think this is the best compromise. It is a breaking change, but most will not be impacted in any meaningful way. If others have a better idea though I'd love to hear it. This PR lays up the foundations for #399 which would be significantly easier once this is merged. But let's discuss.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
