### PR TITLE
Add support for `attributesToSearchOn` in search API

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -188,6 +188,16 @@ search_parameter_guide_page_1: |-
         print(error)
     }
   }
+search_parameter_guide_attributes_to_search_on_1: |-
+  let searchParameters = SearchParameters(query: "adventure", attributesToSearchOn: ["overview"])
+  client.index("movies").search(searchParameters) { (result: Result<Searchable<Movie>, Swift.Error>) in
+    switch result {
+    case .success(let searchResult):
+        print(searchResult)
+    case .failure(let error):
+        print(error)
+    }
+  }
 authorization_header_1: |-
   client = try MeiliSearch(host: "http://localhost:7700", apiKey: "masterKey")
   client.getKeys { result in

--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -32,6 +32,9 @@ public struct SearchParameters: Codable, Equatable {
   /// Which attributes to crop.
   public let attributesToCrop: [String]?
 
+  /// Attributes to search on.
+  public let attributesToSearchOn: [String]?
+
   /// Limit length at which to crop specified attributes.
   public let cropLength: Int?
 
@@ -69,6 +72,7 @@ public struct SearchParameters: Codable, Equatable {
     hitsPerPage: Int? = nil,
     attributesToRetrieve: [String]? = nil,
     attributesToCrop: [String]? = nil,
+    attributesToSearchOn: [String]? = nil,
     cropLength: Int? = nil,
     cropMarker: String? = nil,
     attributesToHighlight: [String]? = nil,
@@ -85,6 +89,7 @@ public struct SearchParameters: Codable, Equatable {
     self.page = page
     self.attributesToRetrieve = attributesToRetrieve
     self.attributesToCrop = attributesToCrop
+    self.attributesToSearchOn = attributesToSearchOn
     self.cropLength = cropLength
     self.cropMarker = cropMarker
     self.attributesToHighlight = attributesToHighlight
@@ -116,6 +121,7 @@ public struct SearchParameters: Codable, Equatable {
     case limit
     case attributesToRetrieve
     case attributesToCrop
+    case attributesToSearchOn
     case cropLength
     case cropMarker
     case attributesToHighlight


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #397

## What does this PR do?
- Add support for `attributesToSearchOn` in search API

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
