### PR TITLE
Allow Custom Headers

### DIFF
--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -33,14 +33,11 @@ public struct MeiliSearch {
    - parameter host:   The host to the Meilisearch http server.
    - parameter apiKey:    The authorization key to communicate with Meilisearch.
    - parameter session:   A custom produced `URLSessionProtocol`.
+   - parameter headers: A dictionary of custom headers passed with every API request.
    */
-  public init(host: String, apiKey: String? = nil, session: URLSessionProtocol? = nil, request: Request? = nil) throws {
-    self.config = try Config(host: host, apiKey: apiKey, session: session).validate()
-    if let request: Request = request {
-      self.request = request
-    } else {
-      self.request = Request(self.config)
-    }
+  public init(host: String, apiKey: String? = nil, session: URLSessionProtocol? = nil, headers: [String: String] = [:]) throws {
+    self.config = try Config(host: host, apiKey: apiKey, session: session, headers: headers).validate()
+    self.request = Request(self.config)
     self.keys = Keys(self.request)
     self.stats = Stats(self.request)
     self.system = System(self.request)

--- a/Sources/MeiliSearch/Config.swift
+++ b/Sources/MeiliSearch/Config.swift
@@ -16,7 +16,10 @@ public class Config {
   let apiKey: String?
 
   /// Custom URL session useful to replace the native network library.
-  var session: URLSessionProtocol?
+  let session: URLSessionProtocol?
+
+  /// Custom headers provided along with each request.
+  let headers: [String: String]
 
   // MARK: Initializers
 
@@ -31,10 +34,13 @@ public class Config {
   public init(
     host: String,
     apiKey: String? = nil,
-    session: URLSessionProtocol? = URLSession.shared) {
+    session: URLSessionProtocol? = URLSession.shared,
+    headers: [String: String] = [:]
+  ) {
     self.host = host
     self.apiKey = apiKey
     self.session = session
+    self.headers = headers
   }
 
   // MARK: Build URL

--- a/Tests/MeiliSearchIntegrationTests/Support/NestedBook.swift
+++ b/Tests/MeiliSearchIntegrationTests/Support/NestedBook.swift
@@ -31,10 +31,4 @@ public struct FormattedNestedBook: Codable, Equatable {
   let id: String
   let title: String
   let info: InfoNested
-
-  init(id: String, title: String, info: InfoNested) {
-    self.id = id
-    self.title = title
-    self.info = info
-  }
 }

--- a/Tests/MeiliSearchUnitTests/ClientTests.swift
+++ b/Tests/MeiliSearchUnitTests/ClientTests.swift
@@ -45,6 +45,26 @@ class ClientTests: XCTestCase {
     }
   }
 
+  func testCustomHeaders() throws {
+    self.session.pushEmpty(code: 200)
+
+    let config = Config(
+      host: self.validHost,
+      apiKey: self.key,
+      session: self.session,
+      headers: [
+        "Custom": "test",
+        "Authorization": "will be overridden"
+      ]
+    )
+
+    let url = try XCTUnwrap(URL(string: validHost))
+    let request = Request(config).request(.get, url)
+    XCTAssertEqual(request.allHTTPHeaderFields?["Custom"], "test")
+    XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer \(key)")
+    XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], PackageVersion.qualifiedVersion())
+  }
+
   func testGETHeaders() {
     self.session.pushEmpty(code: 200)
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #290

## What does this PR do?
- Adds a new parameter to initialiser to allow passing through of custom headers
- Custom header will not override API key which takes highest precedence
- Remove unused request parameter
- Remove unused header parameters in network functions

Though the public signature does change (for removal of 'request'), it was never possible to initialise your own Request due to no public initialiser being provided. As such it's impossible for any client to have this parameter in use, and thus this is **not** a breaking change.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
