### PR TITLE
Remove bors and use GitHub merge queue

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -28,7 +28,5 @@ template: |
 no-changes-template: 'Changes are coming soon 😎'
 sort-direction: 'ascending'
 replacers:
-  - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
-    replace: ''
   - search: '/(?:and )?@meili-bot,?/g'
     replace: ''

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,9 @@ name: Tests
 on:
   pull_request:
   push:
-    # trying and staging branches are for BORS config
     branches:
-      - trying
-      - staging
       - main
+  merge_group:
 
 jobs:
   integration_tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,18 +111,12 @@ Some notes on GitHub PRs:
 
 - [Convert your PR as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/changing-the-stage-of-a-pull-request) if your changes are a work in progress: no one will review it until you pass your PR as ready for review.<br>
   The draft PR can be very useful if you want to show that you are working on something and make your work visible.
-- The branch related to the PR must be **up-to-date with `main`** before merging. Fortunately, this project [integrates a bot](https://github.com/meilisearch/integration-guides/blob/main/resources/bors.md) to automatically enforce this requirement without the PR author having to do it manually.
 - All PRs must be reviewed and approved by at least one maintainer.
 - The PR title should be accurate and descriptive of the changes. The title of the PR will be indeed automatically added to the next [release changelogs](https://github.com/meilisearch/meilisearch-swift/releases/).
 
 ## Release Process (for the internal team only)
 
 Meilisearch tools follow the [Semantic Versioning Convention](https://semver.org/).
-
-### Automation to Rebase and Merge the PRs <!-- omit in TOC -->
-
-This project integrates a bot that helps us manage pull requests merging.<br>
-_[Read more about this](https://github.com/meilisearch/integration-guides/blob/main/resources/bors.md)._
 
 ### Automated Changelogs <!-- omit in TOC -->
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 <p align="center">
   <a href="https://github.com/meilisearch/meilisearch-swift/actions"><img src="https://github.com/meilisearch/meilisearch-swift/workflows/Tests/badge.svg" alt="GitHub Workflow Status"></a>
   <a href="https://github.com/meilisearch/meilisearch-swift/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-informational" alt="License"></a>
-  <a href="https://ms-bors.herokuapp.com/repositories/45"><img src="https://bors.tech/images/badge_small.svg" alt="Bors enabled"></a>
 </p>
 
 <p align="center">⚡ The Meilisearch API client written for Swift 🍎</p>


### PR DESCRIPTION
Ruleset set up for the usage of GitHub merge queue ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified contributor documentation by removing PR automation and rebasing guidance.
  * Removed project branding reference from README.

* **Chores**
  * Updated CI/CD workflow trigger configuration to use new event mechanisms instead of branch-specific triggers.
  * Removed bot mention pattern from release template configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->