### PR TITLE
Update outdated documentation links

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -156,7 +156,7 @@ reset_non_separator_tokens_1: |-
     // handle result
   }
 authorization_header_1: |-
-  client = try MeiliSearch(host: "MEILISEARCH_URL", apiKey: "masterKey")
+  client = try MeiliSearch(host: "MEILISEARCH_URL", apiKey: "MEILISEARCH_KEY")
   client.getKeys { result in
       switch result {
       case .success(let keys):

--- a/Sources/MeiliSearch/Model/KeyAction.swift
+++ b/Sources/MeiliSearch/Model/KeyAction.swift
@@ -1,4 +1,4 @@
-///Documentation: https://www.meilisearch.com/docs/reference/api/keys#actions
+///Documentation: https://www.meilisearch.com/docs/reference/api/keys/list-api-keys#actions
 public enum KeyAction: Equatable, Codable {
   case wildcard
   case search


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs