### PR TITLE
Add `distinct` search parameter

### DIFF
--- a/Sources/MeiliSearch/Model/SearchParameters.swift
+++ b/Sources/MeiliSearch/Model/SearchParameters.swift
@@ -68,6 +68,9 @@ public struct SearchParameters: Codable, Equatable {
   /// Whether to return the ranking score details or not.
   public let showRankingScoreDetails: Bool?
 
+  /// Attribute whose value must be different for each returned document.
+  public let distinct: String?
+
   // MARK: Initializers
 
   public init(
@@ -89,7 +92,8 @@ public struct SearchParameters: Codable, Equatable {
     facets: [String]? = nil,
     showMatchesPosition: Bool? = nil,
     showRankingScore: Bool? = nil,
-    showRankingScoreDetails: Bool? = nil
+    showRankingScoreDetails: Bool? = nil,
+    distinct: String? = nil
   ) {
     self.query = query
     self.offset = offset
@@ -110,6 +114,7 @@ public struct SearchParameters: Codable, Equatable {
     self.showMatchesPosition = showMatchesPosition
     self.showRankingScore = showRankingScore
     self.showRankingScoreDetails = showRankingScoreDetails
+    self.distinct = distinct
   }
 
   // MARK: Query Initializers


### PR DESCRIPTION
## Summary
Adds `distinct` parameter to `SearchParameters` for Meilisearch v1.9+.

## Why this matters
Meilisearch v1.9 introduced `distinct` for search requests. The Swift SDK was missing it. Users couldn't deduplicate search results by attribute.

## Changes
- Added `distinct: String?` property to `SearchParameters` in `Sources/MeiliSearch/Model/SearchParameters.swift`
- Added `distinct` parameter to the initializer with default `nil`

## Testing
- Since `SearchParameters` is `Codable`, the new field serializes to JSON automatically when set
- Default `nil` means existing code is unaffected

Closes #446

This contribution was developed with AI assistance (Claude Code).