### PR TITLE
Add method to get task documents

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -325,6 +325,9 @@ get_task_1: |-
             print(error)
         }
     }
+get_task_documents_1: |-
+  let documents: [MyDocument] = try await client.getTaskDocuments(taskUid: 1)
+  print(documents)
 get_all_tasks_1: |-
   client.getTasks { (result) in
       switch result {

--- a/Sources/MeiliSearch/Async/Client+async.swift
+++ b/Sources/MeiliSearch/Async/Client+async.swift
@@ -113,6 +113,17 @@ extension MeiliSearch {
   }
 
   /**
+   See `getTaskDocuments(taskUid:_:)`
+   */
+  public func getTaskDocuments<T>(taskUid: Int) async throws -> [T] where T: Decodable {
+    try await withCheckedThrowingContinuation { continuation in
+      self.getTaskDocuments(taskUid: taskUid) { (result: Result<[T], Swift.Error>) in
+        continuation.resume(with: result)
+      }
+    }
+  }
+
+  /**
    See `cancelTasks(filter:completion:)`
    */
   public func cancelTasks(filter: CancelTasksQuery) async throws -> TaskInfo {

--- a/Sources/MeiliSearch/Client.swift
+++ b/Sources/MeiliSearch/Client.swift
@@ -207,6 +207,22 @@ public struct MeiliSearch {
   }
 
   /**
+   Retrieve the list of documents that were processed or affected by a given task.
+   Only available for document-related tasks.
+
+   - parameter taskUid: The task unique identifier.
+   - parameter completion: The completion closure is used to notify when the server
+   completes the query request, it returns a `Result` object that contains `[T]` value.
+   If the request was successful or `Error` if a failure occurred.
+   */
+  public func getTaskDocuments<T>(
+    taskUid: Int,
+    _ completion: @escaping (Result<[T], Swift.Error>) -> Void)
+  where T: Decodable {
+    self.tasks.getTaskDocuments(taskUid: taskUid, completion)
+  }
+
+  /**
    Cancel any number of enqueued or processing tasks, stopping them from continuing to run
 
    - parameter filter: The filter in which chooses which tasks will be canceled

--- a/Sources/MeiliSearch/Tasks.swift
+++ b/Sources/MeiliSearch/Tasks.swift
@@ -164,12 +164,15 @@ struct Tasks {
 
   private static func decodeNDJSON<T: Decodable>(_ data: Data) throws -> [T] {
     let decoder = Constants.customJSONDecoder
-    guard let string = String(data: data, encoding: .utf8) else {
-      throw MeiliSearch.Error.invalidJSON
-    }
-    let lines = string.split(separator: "\n", omittingEmptySubsequences: true)
-    return try lines.map { line in
-      guard let lineData = line.data(using: .utf8) else {
+    let newline = UInt8(0x0A)
+    let cr = UInt8(0x0D)
+    let chunks = data.split(separator: newline, omittingEmptySubsequences: true)
+    return try chunks.map { chunk in
+      var lineData = Data(chunk)
+      if lineData.last == cr {
+        lineData.removeLast()
+      }
+      guard !lineData.isEmpty else {
         throw MeiliSearch.Error.invalidJSON
       }
       return try decoder.decode(T.self, from: lineData)

--- a/Sources/MeiliSearch/Tasks.swift
+++ b/Sources/MeiliSearch/Tasks.swift
@@ -137,6 +137,45 @@ struct Tasks {
       }
   }
 
+  // MARK: Get Task Documents
+
+  func getTaskDocuments<T>(
+    taskUid: Int,
+    _ completion: @escaping (Result<[T], Swift.Error>) -> Void)
+  where T: Decodable {
+    self.request.get(api: "/tasks/\(taskUid)/documents") { result in
+      switch result {
+      case .success(let data):
+        guard let data = data else {
+          completion(.failure(MeiliSearch.Error.dataNotFound))
+          return
+        }
+        do {
+          let documents: [T] = try Tasks.decodeNDJSON(data)
+          completion(.success(documents))
+        } catch {
+          completion(.failure(error))
+        }
+      case .failure(let error):
+        completion(.failure(error))
+      }
+    }
+  }
+
+  private static func decodeNDJSON<T: Decodable>(_ data: Data) throws -> [T] {
+    let decoder = Constants.customJSONDecoder
+    guard let string = String(data: data, encoding: .utf8) else {
+      throw MeiliSearch.Error.invalidJSON
+    }
+    let lines = string.split(separator: "\n", omittingEmptySubsequences: true)
+    return try lines.map { line in
+      guard let lineData = line.data(using: .utf8) else {
+        throw MeiliSearch.Error.invalidJSON
+      }
+      return try decoder.decode(T.self, from: lineData)
+    }
+  }
+
   // MARK: Cancel Tasks
 
   func cancelTasks(

--- a/Tests/MeiliSearchUnitTests/TasksTests.swift
+++ b/Tests/MeiliSearchUnitTests/TasksTests.swift
@@ -13,6 +13,43 @@ class TasksTests: XCTestCase {
     index = client.index(self.uid)
   }
 
+  func testGetTaskDocumentsFromClient() async throws {
+    let ndjsonString = """
+    {"id":1,"title":"Movie 1"}
+    {"id":2,"title":"Movie 2"}
+    """
+
+    struct SimpleDoc: Decodable, Equatable {
+      let id: Int
+      let title: String
+    }
+
+    session.pushData(ndjsonString)
+
+    let documents: [SimpleDoc] = try await self.client.getTaskDocuments(taskUid: 1)
+
+    XCTAssertEqual(documents.count, 2)
+    XCTAssertEqual(documents[0].id, 1)
+    XCTAssertEqual(documents[0].title, "Movie 1")
+    XCTAssertEqual(documents[1].id, 2)
+    XCTAssertEqual(documents[1].title, "Movie 2")
+
+    let requestPath = self.session.nextDataTask.request?.url?.path
+    XCTAssertEqual(requestPath, "/tasks/1/documents")
+  }
+
+  func testGetTaskDocumentsEmptyResponse() async throws {
+    session.pushData("")
+
+    struct SimpleDoc: Decodable, Equatable {
+      let id: Int
+    }
+
+    let documents: [SimpleDoc] = try await self.client.getTaskDocuments(taskUid: 1)
+
+    XCTAssertEqual(documents.count, 0)
+  }
+
   func testGetTasksWithParametersFromClient() async throws {
     let jsonString = """
       {

--- a/Tests/MeiliSearchUnitTests/TasksTests.swift
+++ b/Tests/MeiliSearchUnitTests/TasksTests.swift
@@ -50,6 +50,22 @@ class TasksTests: XCTestCase {
     XCTAssertEqual(documents.count, 0)
   }
 
+  func testGetTaskDocumentsMalformedResponse() async throws {
+    session.pushData("""
+    {"id":1}
+    not-json
+    """)
+
+    struct SimpleDoc: Decodable { let id: Int }
+
+    do {
+      let _: [SimpleDoc] = try await self.client.getTaskDocuments(taskUid: 1)
+      XCTFail("Expected decoding to fail")
+    } catch {
+      XCTAssertNotNil(error)
+    }
+  }
+
   func testGetTasksWithParametersFromClient() async throws {
     let jsonString = """
       {


### PR DESCRIPTION
## Summary

- Adds `getTaskDocuments` method implementing `GET /tasks/{taskUid}/documents` (Meilisearch v1.13)
- Handles NDJSON response format by parsing each newline-delimited JSON line
- Includes callback-based and async/await APIs
- Adds unit tests for normal and empty responses
- Adds code sample under `get_task_documents_1`

Closes #513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now retrieve documents associated with a specific task, including an async/await convenience variant.

* **Documentation**
  * Added a usage example demonstrating how to fetch task documents.

* **Tests**
  * Added test coverage for task document retrieval, including success, empty response, and malformed-response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->